### PR TITLE
chore(requirements): add falconpy library to docker req for crowdstrike installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ docker==6.1.3
 jmespath==1.0.1
 python-dateutil==2.8.2
 pytz==2023.3.post1
+crowdstrike-falconpy==1.3.3


### PR DESCRIPTION
**Description**

Crowdstrike is a security tool used by many enterprises to secure their environments. They developed a tool called Falcon Sensor that allows to scan all sorts of hosts to check for security breaches or issues. The falcon sensor has the crowdstrike-falconpy python library as a requirement. We are using your action as our based ansible playbook deployment controller node across our large environments. I would like to add that requirement in your docker requirements in order to be able to deploy the crowdstrike tool

**pypi link**: [crowdstrike-falconpy](https://pypi.org/project/crowdstrike-falconpy/)