### PR TITLE
➕ add passlib so password_hash doesn't show deprecation messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ openshift==0.13.2
 lxml==5.1.0
 docker==7.0.0
 jmespath==1.0.1
+passlib==1.7.4
 python-dateutil==2.9.0.post0
 pytz==2024.1
 crowdstrike-falconpy==1.4.1


### PR DESCRIPTION
we are happily using this container in our CI pipeline (using the ansible action). However we are using the password_hash filter quite a lot and it shows deprecation messages:

```
[mop@udoo-juergens docker.ansible]$ docker run -it ansible bash                                                                
d29af6796d33:/$ ansible localhost -m debug -a "msg={{ 'aaa'| password_hash('bcrypt') }}"
[DEPRECATION WARNING]: Encryption using the Python crypt module is deprecated. The Python crypt module is deprecated and will 
be removed from Python 3.13. Install the passlib library for continued encryption functionality. This feature will be removed 
in version 2.17. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
localhost | SUCCESS => {
    "msg": "$2b$12$MMy7PxskRBI761ttsVKVU.AHIo3UbHtjId3GvhjETB5I93yN2wUnC"
}
```

this is a somewhat ticking bomb for us. Of course this is a super subjective view but I think the password_hash filter is vital enough to justify inclusion into this docker image. What do you think?

After building the container with passlib included:

```
[mop@udoo-juergens docker.ansible]$ docker run -it ansible bash                                                         
57f130c30ad2:/$ ansible localhost -m debug -a "msg={{ 'aaa'| password_hash('bcrypt') }}"
localhost | SUCCESS => {
    "msg": "$2b$12$GhQ8vAg7t3BWC0lNrYvkxuK383jBVMk5JgZcC0Pq6JJuBnCa6bvO6"
}
```