### PR TITLE
Refactor: Externalizes deployment test to script

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -274,45 +274,7 @@ jobs:
 
             - name: Comprehensive Deployment Test
               run: |
-                  mkdir -p deploy-test-results
-
-                  echo "=== Running Ansible Runtime Tests ==="
-                  docker run --rm ansible-test:test \
-                    ansible-playbook -c local -i localhost, -e "test_var=deployment_test" \ # DevSkim: ignore DS162092
-                    /dev/stdin <<EOF
-                  ---
-                  - name: Final Deployment Validation
-                    hosts: all
-                    gather_facts: false
-                    tasks:
-                      - name: "Deployment Test"
-                        debug:
-                          msg: "Ansible Deployment Test successful: {{ test_var }}"
-
-                      - name: "Check Environment"
-                        command: env
-                        register: env_output
-                        changed_when: false
-
-                      - name: "Check Installed Ansible Modules"
-                        command: ansible-doc -l
-                        register: modules
-                        changed_when: false
-
-                      - name: "Save Test Results"
-                        copy:
-                          content: |
-                            ANSIBLE DEPLOYMENT TEST RESULTS
-                            ===============================
-                            Date: {{ ansible_date_time.iso8601 }}
-                            Python: {{ ansible_python.version.major }}.{{ ansible_python.version.minor }}.{{ ansible_python.version.micro }}
-                            Ansible: {{ ansible_version.full }}
-
-                            Available Modules: {{ modules.stdout_lines | length }}
-                          dest: "/tmp/deployment-test-results.txt"
-                  EOF
-
-                  echo "=== Test completed ==="
+                  tests/structure/run-deployment-test.sh ${{ steps.get_version.outputs.version }}
 
             - name: Publish Test Status
               id: test_status

--- a/tests/final-validation/final-deployment-validation.yml
+++ b/tests/final-validation/final-deployment-validation.yml
@@ -1,0 +1,31 @@
+---
+- name: Final Deployment Validation
+  hosts: all
+  gather_facts: true
+  tasks:
+      - name: "Deployment Test"
+        ansible.builtin.debug:
+            msg: "Ansible Deployment Test successful: {{ test_var }}"
+
+      - name: "Check Environment"
+        ansible.builtin.command: env
+        register: env_output
+        changed_when: false
+
+      - name: "Check Installed Ansible Modules"
+        ansible.builtin.command: ansible-doc -l
+        register: modules
+        changed_when: false
+
+      - name: "Save Test Results"
+        ansible.builtin.copy:
+            content: |
+                ANSIBLE DEPLOYMENT TEST RESULTS
+                ===============================
+                Date: {{ ansible_date_time.iso8601 }}
+                Python: {{ ansible_python.version.major }}.{{ ansible_python.version.minor }}.{{ ansible_python.version.micro }}
+                Ansible: {{ ansible_version.full }}
+
+                Available Modules: {{ modules.stdout_lines | length }}
+            dest: "/tmp/deployment-test-results.txt"
+            mode: "0644"

--- a/tests/final-validation/run-deployment-test.sh
+++ b/tests/final-validation/run-deployment-test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Set up error handling
+set -e
+
+# Script variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAYBOOK_PATH="${SCRIPT_DIR}/final-deployment-validation.yml"
+RESULTS_DIR="${SCRIPT_DIR}/../../deploy-test-results"
+
+# Function to run deployment tests
+run_deployment_tests() {
+    local image_tag="${1:-test}"
+
+    # Setup result directory
+    mkdir -p "${RESULTS_DIR}"
+
+    # Execute tests
+    echo "=== Running Ansible Runtime Tests ==="
+    docker run --rm \
+        -v "${PLAYBOOK_PATH}:/playbook.yml" \
+        "ansible-test:${image_tag}" \
+        ansible-playbook -c local -i localhost, -e "test_var=deployment_test" /playbook.yml # DevSkim: ignore DS162092
+
+    # Copy test results from container
+    echo "=== Collecting Test Results ==="
+    docker run --rm \
+        -v "${RESULTS_DIR}:/output" \
+        "ansible-test:${image_tag}" \
+        sh -c "if [ -f /tmp/deployment-test-results.txt ]; then cp /tmp/deployment-test-results.txt /output/; else echo 'No test results found' > /output/error.txt; fi"
+
+    echo "=== Test completed ==="
+}
+
+# Main execution
+main() {
+    # Check if a specific tag was provided
+    if [ $# -eq 1 ]; then
+        run_deployment_tests "$1"
+    else
+        run_deployment_tests
+    fi
+}
+
+# Execute the script
+main "$@"


### PR DESCRIPTION
Moves the deployment test logic into a separate shell script. This promotes reusability and improves maintainability.  The script runs within a container and copies the test results to a persistent volume.

The script accepts an optional image tag, which allows testing against different versions of the Ansible test image.