### PR TITLE
Fix: Renovate detects image digests in Makefiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -138,10 +138,11 @@
                         "customType": "regex",
                         "fileMatch": ["^Makefile$"],
                         "matchStrings": [
-                                "docker\\s+run\\s+(?:[^\\n]*?\\s+)(?<depName>[a-z0-9/-]+(?:[.][a-z0-9]+)+\\/[a-z0-9/-]+|[a-z0-9/-]+/[a-z0-9/-]+|busybox):(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+|[0-9]+\\.[0-9]+)"
+                                "docker\\s+run\\s+(?:[^\\n]*?\\s+)(?<depName>[a-z0-9/-]+(?:[.][a-z0-9]+)+\\/[a-z0-9/-]+|[a-z0-9/-]+/[a-z0-9/-]+|busybox):(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+|[0-9]+\\.[0-9]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
                         ],
                         "datasourceTemplate": "docker",
-                        "versioningTemplate": "semver"
+                        "versioningTemplate": "semver",
+                        "autoReplaceStringTemplate": "{{depName}}:{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}"
                 },
                 {
                         "description": "Container Structure Test in GitHub workflows",


### PR DESCRIPTION
This commit updates the Renovate configuration to correctly identify and update Docker image digests specified in Makefiles.

The previous configuration only considered image tags. This change extends the regex to also capture and update the image digest (sha256 hash), ensuring that Renovate can propose updates to specific image versions identified by their digest. It also adds an `autoReplaceStringTemplate` to correctly update the image name and tag, as well as the digest, if available.