### PR TITLE
fix(tests): update expected OpenSSL version to 3.5.6

### DIFF
--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -48,7 +48,7 @@ commandTests:
       args: ["version"]
       expectedOutput:
           # renovate: datasource=repology depName=openssl versioning=loose
-          - "OpenSSL 3.5.5"
+          - "OpenSSL 3.5.6"
 
     - name: "Check Git Version"
       command: "git"


### PR DESCRIPTION
## Summary
- Alpine updated OpenSSL from 3.5.5 to 3.5.6, causing the structure test `Check OpenSSL Version` to fail
- Updates the expected version in `container-test.yml` to match the current Alpine package
- Fixes CI failures on #445 and #448

## Test plan
- [ ] Structure Test passes with the updated OpenSSL version expectation
- [ ] All other structure tests remain unaffected