### PR TITLE
fix(ci): add explicit SARIF upload categories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ name: Continuous Integration
         - cron: "0 1 * * 3" # Wednesday at 1:00 UTC
     workflow_dispatch:
     workflow_call:
+        inputs:
+            upload-sarif:
+                description: "Upload SARIF results to GitHub Code Scanning"
+                type: boolean
+                default: true
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -166,10 +171,10 @@ jobs:
                   severity: "CRITICAL,HIGH"
 
             - name: Upload Trivy scan results
+              if: ${{ inputs.upload-sarif != false }}
               uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
               with:
                   sarif_file: "trivy-results.sarif"
-                  category: "security-test"
 
     performance-test:
         name: Performance Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
               uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
               with:
                   sarif_file: "trivy-results.sarif"
+                  category: "security-test"
 
     performance-test:
         name: Performance Test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
     ci:
         name: Continuous Integration
         uses: ./.github/workflows/ci.yml
+        with:
+            upload-sarif: false
         secrets: inherit
         permissions:
             contents: read
@@ -38,6 +40,8 @@ jobs:
     security:
         name: Security Scanning
         uses: ./.github/workflows/security.yml
+        with:
+            upload-sarif: false
         secrets: inherit
         permissions:
             contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,11 @@ name: Security Scanning
     schedule:
         - cron: "0 2 * * 1" # Weekly Monday 02:00 UTC
     workflow_call:
+        inputs:
+            upload-sarif:
+                description: "Upload SARIF results to GitHub Code Scanning"
+                type: boolean
+                default: true
 
 permissions:
     contents: read
@@ -49,10 +54,9 @@ jobs:
 
             - name: Upload Trivy scan results
               uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
-              if: always()
+              if: ${{ always() && inputs.upload-sarif != false }}
               with:
                   sarif_file: "trivy-results.sarif"
-                  category: "trivy-scan"
 
     secrets:
         name: Secret Scanning

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,6 +52,7 @@ jobs:
               if: always()
               with:
                   sarif_file: "trivy-results.sarif"
+                  category: "trivy-scan"
 
     secrets:
         name: Secret Scanning


### PR DESCRIPTION
## Summary
- Adds explicit `category` to SARIF uploads in `ci.yml` (`security-test`) and `security.yml` (`trivy-scan`)
- Fixes the "2 configurations not found" warning from GitHub Advanced Security on PRs
- Root cause: when `deploy.yml` calls these workflows on main, SARIF uploads get `deploy.yml:`-prefixed categories that don't exist on PRs where the workflows run directly

## Test plan
- [ ] GitHub Advanced Security / Trivy check no longer warns about missing configurations on PRs
- [ ] SARIF results still upload correctly on main branch deployments