### PR TITLE
fix(build): raise ca-certificates upper bound to <20270000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache \
 	'pipx>=1.7.0' \
 	'pipx<2.0.0' \
 	'ca-certificates>=20250619' \
-	'ca-certificates<20260000' \
+	'ca-certificates<20270000' \
 	'git>=2.49.0' \
 	'git<3.0.0' \
 	# Compiler toolchain - allow patch updates


### PR DESCRIPTION
## Summary
- Alpine released `ca-certificates-20260413-r0`, which violates the existing `<20260000` calendar-version cap in [Dockerfile:51](Dockerfile#L51).
- Every CI build (builder + Trivy stage) on `main` and on all open PRs (#445, #448, #451, #452, #453, #454) fails with `breaks: world[ca-certificates<20260000]`.
- Bumps the upper bound to `<20270000` so 2026-dated patches install. Stays consistent with the YYYYMMDD calendar-versioning style used for this package.

## Test plan
- [ ] CI Build Container stage succeeds
- [ ] Trivy Scan stage succeeds
- [ ] After merge: rebase the open Renovate/Dependabot PRs and confirm they go green