### PR TITLE
fix(deps): comment out fabric until invoke 3 is supported upstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,10 @@ prometheus-client==0.24.1
 statsd==4.0.1
 
 # SSH & Terminal
-fabric==3.2.2
+# fabric is unused in this repo and pins invoke<3.0; re-enable once
+# upstream releases a fabric version that supports invoke 3 (see
+# https://github.com/fabric/fabric main branch)
+# fabric==3.2.2
 invoke==3.0.3
 
 # Time & Scheduling

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,9 +98,12 @@ prometheus-client==0.24.1
 statsd==4.0.1
 
 # SSH & Terminal
-# fabric is unused in this repo and pins invoke<3.0; re-enable once
-# upstream releases a fabric version that supports invoke 3 (see
-# https://github.com/fabric/fabric main branch)
+# fabric is unused in this repo and pins invoke<3.0. Re-enable once
+# a fabric release with invoke>=3 ships on PyPI.
+# Upstream pinned 3.x to invoke<3 here:
+#   https://github.com/fabric/fabric/commit/ca9cf7a1da7ae9257822798adc492657d65b3a67
+# Invoke 3.x adoption work landed in:
+#   https://github.com/fabric/fabric/commit/7fa309db9dd5dac69079c1fb83b6f579555f7d53
 # fabric==3.2.2
 invoke==3.0.3
 


### PR DESCRIPTION
## Summary
- `fabric` 3.2.x pins `invoke<3.0,>=2.0`; #451 bumped invoke to 3.0.3, leaving main with a latent dependency conflict.
- pip 26.0.1 (currently in main) tolerates the violation with a warning, which is why #451's CI passed and the conflict went unnoticed.
- pip 26.1 (the bump in #445) enforces the resolution strictly → `ResolutionImpossible` in both Build Container and Trivy Scan.
- `fabric` is **not imported or referenced anywhere** in this repo; it is dead weight in `requirements.txt`.
- Upstream `fabric/fabric` `main` already requires `invoke>=3`, but no release with that change is published on PyPI yet — `Fabric3` is an unrelated 2018-abandoned 1.x fork.
- Comment the line out (rather than delete) to leave a paper trail for re-enabling once a compatible release lands.

## Test plan
- [ ] CI Build Container green (no pip resolution error)
- [ ] Trivy Scan green
- [ ] After merge: rebase #445, expect a clean run