### PR TITLE
fix(ci): bump OpenSSL test assertion and widen apk upper bounds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY requirements.txt /requirements.txt
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
 	'py3-pip>=25.1.0' \
-	'py3-pip<26.0.0' \
+	'py3-pip<27.0.0' \
 	'pipx>=1.7.0' \
 	'pipx<2.0.0' \
 	'ca-certificates>=20250619' \
@@ -57,7 +57,7 @@ RUN apk add --no-cache \
 	'libffi-dev>=3.4.0' \
 	'libffi-dev<4.0.0' \
 	'python3-dev>=3.12.0' \
-	'python3-dev<3.13.0' \
+	'python3-dev<3.14.0' \
 	'make>=4.4.0' \
 	'make<5.0.0' \
 	'musl-dev>=1.2.0' \

--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -48,7 +48,7 @@ commandTests:
       args: ["version"]
       expectedOutput:
           # renovate: datasource=repology depName=openssl versioning=loose
-          - "OpenSSL 3.5.6"
+          - "OpenSSL 3.5.7"
 
     - name: "Check Git Version"
       command: "git"


### PR DESCRIPTION
## Summary

The Structure Test currently fails on every open PR. Two unrelated root causes, both fixed here:

- **OpenSSL assertion drift** — `tests/structure/container-test.yml` pinned `OpenSSL 3.5.6`, but the Alpine package repo now ships `3.5.7` (9 Jun 2026) for both the 3.23 and 3.24 branches. The `Check OpenSSL Version` command test fails as a result. Bumped to `3.5.7`.
- **apk upper bounds too tight for Alpine 3.24** — the `renovate/all-non-major` PR (#475) bumps the base image to `alpine:3.24.0`, which ships `py3-pip` 26.x and `python3-dev` 3.13.x. The Dockerfile pinned `py3-pip<26.0.0` and `python3-dev<3.13.0`, so `apk add` could not resolve (`breaks: world[py3-pip<26.0.0]`). Widened to `<27.0.0` / `<3.14.0`. Bounds stay ranges per the project convention (no exact patch pins).

## Why first

This unblocks the three stuck Renovate PRs (#475, #483, #482) — once merged, they rebase to green.

## Testing

- Verified OpenSSL package version is `3.5.7` in both `alpine:3.23.4` (current `main`) and `alpine:3.24.0` (#475), so this PR goes green against `main` and the widened bounds still include the older Alpine 3.23 package versions.
- CI Structure Test + Build Container on this PR.