### PR TITLE
fix(ci): widen python3-dev upper bound to <3.15.0 for Alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apk add --no-cache \
 	'libffi-dev>=3.4.0' \
 	'libffi-dev<4.0.0' \
 	'python3-dev>=3.12.0' \
-	'python3-dev<3.14.0' \
+	'python3-dev<3.15.0' \
 	'make>=4.4.0' \
 	'make<5.0.0' \
 	'musl-dev>=1.2.0' \


### PR DESCRIPTION
## Summary

Follow-up to #484. The `python3-dev` upper bound was widened to `<3.14.0`, but Alpine 3.24 actually ships `python3` / `python3-dev` **3.14.5**, so `apk add` still failed to resolve on the `all-non-major` PR (#475) with `breaks: world[python3-dev<3.14.0]`. Widen to `<3.15.0`.

## Verification

Read the apk package index directly:

| Alpine | python3-dev | py3-pip |
|--------|-------------|---------|
| 3.23.4 (current `main`) | 3.12.13 | 25.1.1 |
| 3.24.0 (incoming via #475) | 3.14.5 | 26.1.2 |

`python3-dev >=3.12.0 <3.15.0` covers both, so this PR is green against `main` and unblocks #475. Bound stays a range per the project convention (no exact patch pins).