### PR TITLE
fix(ci): widen production-stage python3 and kubectl bounds for Alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/v$(cut -d'.' -f1-2 /etc/alpine-re
 	apk add --no-cache \
 	# Base packages - conservative ranges
 	'python3>=3.12.0' \
-	'python3<3.13.0' \
+	'python3<3.15.0' \
 	'bash>=5.2.0' \
 	'bash<5.4.0' \
 	# VCS and networking
@@ -127,7 +127,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/v$(cut -d'.' -f1-2 /etc/alpine-re
 	'rsync<4.0.0' \
 	# Kubernetes tools - allow minor updates
 	'kubectl>=1.33.0' \
-	'kubectl<1.35.0' \
+	'kubectl<1.37.0' \
 	'helm>=3.18.0' \
 	'helm<4.0.0' \
 	'kustomize>=5.6.0' \


### PR DESCRIPTION
## Summary

Follow-up to #484 and #485. The Dockerfile has **two** apk blocks (builder + production stage); the earlier fixes only touched the builder stage. The production stage pins `python3<3.13.0` and `kubectl<1.35.0`, which Alpine 3.24 (python3 3.14.5, kubectl 1.36.1) exceeds — `apk add` fails with `breaks: world[python3<3.13.0]` / `breaks: world[kubectl<1.35.0]`. Widen to `<3.15.0` / `<1.37.0`.

## Verification — full audit this time

Read the apk index for all 24 pinned packages across both stages, against both Alpine versions:

| Package | 3.23.4 (main) | 3.24.0 (#475) | bound | exceeded? |
|---------|---------------|---------------|-------|-----------|
| python3 | 3.12.13 | 3.14.5 | `<3.13.0`→`<3.15.0` | yes |
| python3-dev | 3.12.13 | 3.14.5 | `<3.15.0` (#485) | fixed |
| kubectl | 1.34.2 | 1.36.1 | `<1.35.0`→`<1.37.0` | yes |
| all others (py3-pip, helm, kustomize, openssl, git, gcc, …) | — | — | — | within range |

These three were the only bounds the 3.24 versions exceed. New ranges cover both Alpine branches, so this PR is green against `main` and finally unblocks #475. Bounds stay ranges per the project convention.