### PR TITLE
fix(tests): resolve python site-packages paths dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 <!-- markdownlint-disable MD024 -->
 
 
+## [Unreleased]
+
+### Changed
+
+- Resolve Python `site-packages` paths via the interpreter instead of a
+  hardcoded `python3.X` directory, so the Makefile `test-local` Mitogen check
+  and the container structure test no longer break on a Python minor bump.
+
+
 ## [2026-06-19]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ test-local: ansible-build ## Run comprehensive local container tests
 	@docker run --rm ansible:latest ansible-inventory --list --yaml | head -10
 	@echo ""
 	@echo "3. Mitogen integration..."
-	@docker run --rm ansible:latest test -d /pipx/venvs/ansible/lib/python3.12/site-packages/ansible_mitogen && echo "Mitogen directory exists"
 	@docker run --rm ansible:latest /pipx/venvs/ansible/bin/python3 -c "import ansible_mitogen; print('Mitogen successfully imported')"
 	@docker run --rm ansible:latest grep "strategy = mitogen_linear" /etc/ansible/ansible.cfg && echo "Mitogen strategy configured"
 	@echo ""

--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -177,11 +177,17 @@ commandTests:
       expectedOutput:
           - "inventory = /etc/ansible/hosts.yml"
 
-fileExistenceTests:
-    - name: "Check Python Dependencies"
-      path: "/pipx/venvs/ansible/lib/python3.14/site-packages"
-      shouldExist: true
+    # Python dependencies: resolve site-packages via the interpreter so the
+    # test does not drift when the Python minor version bumps.
+    - name: "Check Python Dependencies Installed"
+      command: "/pipx/venvs/ansible/bin/python3"
+      args:
+          - "-c"
+          - "import os, sysconfig; p = sysconfig.get_path('purelib'); print('site-packages present' if os.path.isdir(p) and os.listdir(p) else 'missing')"
+      expectedOutput:
+          - "site-packages present"
 
+fileExistenceTests:
     - name: "Check Security-Related Files"
       path: "/etc/ssl/certs/ca-certificates.crt"
       shouldExist: true


### PR DESCRIPTION
## Summary

- Drop the broken hardcoded `python3.12` Mitogen directory check in `make test-local` (image ships Python 3.14, so the dir doesn't exist and the target failed); the version-independent import check on the next line already covers it.
- Resolve the container structure test's site-packages path via `sysconfig.get_path('purelib')` instead of pinning `python3.14`, so it stops drifting on every Python minor bump.

## Test plan

- [ ] CI lint (yamllint, hadolint, shellcheck) green
- [ ] Structure Test job passes the reworked "Check Python Dependencies Installed" command test
- [ ] `make test-local` Mitogen step passes