### PR TITLE
chore(docs,ci): document env vars and harden version extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,11 @@ jobs:
             - name: Extract Ansible Version
               id: get_version
               run: |
-                  version="$(grep '^ansible-core==' requirements.txt | cut -d'=' -f3)"
+                  version="$(sed -n 's/^ansible-core==\([0-9][^[:space:]#]*\).*/\1/p' requirements.txt)"
+                  if [ -z "${version}" ]; then
+                      echo "::error::Could not extract ansible-core version from requirements.txt (expected a line like 'ansible-core==2.21.0')" >&2
+                      exit 1
+                  fi
                   echo "version=${version}" >> "$GITHUB_OUTPUT"
                   echo "Ansible Version: ${version}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Document the image's environment variables (`ANSIBLE_FORCE_COLOR`,
+  `ANSIBLE_HOST_KEY_CHECKING`, `ANSIBLE_CONFIG`) and common SSH-key / Vault
+  mount patterns in the README Quick Start.
+
 ### Changed
 
 - Resolve Python `site-packages` paths via the interpreter instead of a
   hardcoded `python3.X` directory, so the Makefile `test-local` Mitogen check
   and the container structure test no longer break on a Python minor bump.
+- Extract the `ansible-core` version with an anchored `sed` expression that
+  tolerates trailing comments/whitespace and fails fast in CI when no version
+  is found, replacing the brittle `grep | cut` pipeline.
+- Document in the generated `ansible.cfg` why `host_key_checking` is disabled
+  (ephemeral CI hosts) and how to re-enable it for persistent hosts.
 
 
 ## [2026-06-19]

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,11 @@ RUN mkdir -p /etc/ansible && \
 	echo '      ansible_python_interpreter: /pipx/venvs/ansible/bin/python3' >> /etc/ansible/hosts.yml && \
 	echo '[defaults]' > /etc/ansible/ansible.cfg && \
 	echo 'inventory = /etc/ansible/hosts.yml' >> /etc/ansible/ansible.cfg && \
+	# host_key_checking is disabled because this image targets ephemeral
+	# CI/automation runs against freshly provisioned, short-lived hosts
+	# whose host keys are not known ahead of time and would otherwise abort
+	# the first connection. Override at runtime (ANSIBLE_HOST_KEY_CHECKING=True
+	# or a mounted ansible.cfg) when connecting to persistent, trusted hosts.
 	echo 'host_key_checking = False' >> /etc/ansible/ansible.cfg && \
 	echo "strategy_plugins = $(/pipx/venvs/ansible/bin/python3 -c 'import os, ansible_mitogen.plugins.strategy as s; print(os.path.dirname(s.__file__))')" >> /etc/ansible/ansible.cfg && \
 	echo 'strategy = mitogen_linear' >> /etc/ansible/ansible.cfg && \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ansible-build: ## Build the Ansible Docker image with optimizations
 	@echo "Building Ansible container..."
 	@docker build \
 		--build-arg BUILD_DATE=$$(date -I) \
-		--build-arg ANSIBLE_VERSION=$$(grep '^ansible-core==' requirements.txt | cut -d'=' -f3) \
+		--build-arg ANSIBLE_VERSION=$$(sed -n 's/^ansible-core==\([0-9][^[:space:]#]*\).*/\1/p' requirements.txt) \
 		--build-arg VCS_REF=$$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
 		--build-arg TARGETPLATFORM=$$(docker version --format '{{.Server.Arch}}') \
 		-t ansible:latest \
@@ -143,7 +143,7 @@ comprehensive-test: test-quick structure-test security-test performance-test int
 release-check: comprehensive-test ## Comprehensive release readiness check
 	@echo ""
 	@echo "=== RELEASE READINESS CHECK ==="
-	@ansible_version=$$(grep '^ansible-core==' requirements.txt | cut -d'=' -f3); \
+	@ansible_version=$$(sed -n 's/^ansible-core==\([0-9][^[:space:]#]*\).*/\1/p' requirements.txt); \
 	echo "Current Ansible version: $$ansible_version"; \
 	echo "Checking CHANGELOG.md for version entry..."; \
 	if grep -q "$$ansible_version" CHANGELOG.md; then \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ docker run --rm -v $(pwd):/workspace -w /workspace arillso/ansible ansible-playb
 docker run --rm -it -v $(pwd):/workspace -w /workspace arillso/ansible bash
 ```
 
+## Environment Variables
+
+The image needs no environment variables to run. The defaults below are baked
+in; override them with `-e NAME=value` when needed.
+
+| Variable                     | Default            | Purpose                                                              |
+| ---------------------------- | ------------------ | -------------------------------------------------------------------- |
+| `ANSIBLE_FORCE_COLOR`        | `True`             | Colored output even when stdout is not a TTY. Set `False` to disable. |
+| `ANSIBLE_HOST_KEY_CHECKING`  | `False` (via cfg)  | Skips SSH host-key verification. Set `True` for persistent hosts.    |
+| `ANSIBLE_CONFIG`             | `/etc/ansible/ansible.cfg` | Point to a mounted config to override the baked-in defaults. |
+| `PIPX_HOME` / `PATH`         | `/pipx`            | Location of the Ansible virtualenv. Do not change.                  |
+
+Common run-time inputs are passed by mounting, not env vars:
+
+```bash
+# SSH key and connecting to a remote host with host-key checking enabled
+docker run --rm \
+  -e ANSIBLE_HOST_KEY_CHECKING=True \
+  -v $(pwd):/workspace -w /workspace \
+  -v $HOME/.ssh/id_ed25519:/home/ansible/.ssh/id_ed25519:ro \
+  arillso/ansible ansible-playbook -i inventory.yml playbook.yml
+
+# Vault password via file
+docker run --rm \
+  -v $(pwd):/workspace -w /workspace \
+  -v $(pwd)/.vault_pass:/home/ansible/.vault_pass:ro \
+  arillso/ansible ansible-playbook --vault-password-file /home/ansible/.vault_pass playbook.yml
+```
+
 ## Features
 
 - Mitogen enabled by default (2-7x faster execution)


### PR DESCRIPTION
## Summary

- Add a README "Environment Variables" section: the variables baked into the image (`ANSIBLE_FORCE_COLOR`, `ANSIBLE_HOST_KEY_CHECKING`, `ANSIBLE_CONFIG`) plus the SSH-key / Vault mount patterns users actually need — the Quick Start documented none before.
- Replace the brittle `grep '^ansible-core==' | cut -d'=' -f3` extraction in `ci.yml` and the Makefile with an anchored `sed` that tolerates trailing comments/whitespace; the CI step now fails fast with a clear error instead of building with an empty `ANSIBLE_VERSION`.
- Document in the generated `ansible.cfg` why `host_key_checking` is disabled (ephemeral CI hosts) and how to re-enable it.

## Test plan

- [ ] CI lint (yamllint, hadolint, shellcheck) green
- [ ] `prepare` job extracts `2.21.0` and the build runs
- [ ] README renders (markdownlint)