### PR TITLE
fix(renovate): manage alpine base image and document apk range policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 <!-- markdownlint-disable MD024 -->
 
 
+## [Unreleased]
+
+### Changed
+
+- Track the Alpine base image with a Renovate marker on the `FROM` line so its
+  tag and digest update automatically.
+- Document the deliberate loose-range policy for the Dockerfile apk blocks
+  (minor/patch updates ride the Alpine release bump; major ceilings are raised
+  manually because Renovate cannot track apk range expressions).
+
+
 ## [2026-06-19]
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 ##############################################
 # Base Stage: Common configuration
 ##############################################
+# renovate: datasource=docker depName=alpine
 FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4 AS base
 
 # Define OCI labels for all stages
@@ -40,7 +41,15 @@ WORKDIR /home
 # Copy dependencies
 COPY requirements.txt /requirements.txt
 
-# Install all build dependencies in a single layer to reduce image size
+# Install all build dependencies in a single layer to reduce image size.
+#
+# apk versions use loose ranges (>= floor, < next-major ceiling) on purpose:
+# patch and minor updates from the pinned Alpine release flow in automatically
+# on rebuild without touching this file. Renovate manages the Alpine release
+# itself (the marker on the FROM line above); the apk ceilings are bumped
+# manually when a dependency's major changes, since Renovate cannot track apk
+# range expressions. The Alpine release bump is the single update that pulls
+# all package versions forward together.
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
 	'py3-pip>=25.1.0' \
@@ -98,7 +107,9 @@ ENV USER=ansible \
 
 WORKDIR /home/ansible
 
-# Install all runtime dependencies in a single layer
+# Install all runtime dependencies in a single layer.
+# Same loose-range policy as the builder stage above: minor/patch updates ride
+# the Alpine release bump, major ceilings are raised manually.
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # hadolint ignore=DL3018
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/v$(cut -d'.' -f1-2 /etc/alpine-release)/community" >> /etc/apk/repositories && \


### PR DESCRIPTION
## Summary

- Add a `# renovate: datasource=docker depName=alpine` marker on the Dockerfile `FROM` line so the Alpine base image tag **and** digest auto-update (the org preset's custom manager captures both). The base was pinned but completely unmanaged.
- Document the deliberate loose-range policy on both apk blocks: minor/patch ride the Alpine release bump, major ceilings are raised by hand.

## Deferred (ticket A)

Tracking exact apk package versions via Renovate is feasible (repology has `alpine_3_24/` entries for kustomize/jq/openssl; helm is the `kubernetes-helm` project) but requires:
- a dedicated custom manager — the org regex doesn't match apk `pkg=ver` syntax;
- exact pins (`helm=3.19.0-r0`), which conflict with the AGENTS.md "no exact apk pins" rule and risk build breaks when the `-rN` apk build suffix drifts (repology omits it).

Per decision, that work waits on the **pkgproxy** package-cache groundwork first. The earlier repology test-marker change was reverted as part of this (`container-test.yml` is back to its original markers).

## Test plan

- [ ] CI lint (hadolint clean locally), yamllint
- [ ] Build + Structure Test green (no assertion changes)