### PR TITLE
chore(repo): align with arillso repo standard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# The Dockerfile only copies requirements.txt; everything else is build noise.
+# Keeping the context small speeds up `docker build` and avoids leaking local
+# artifacts or secrets into image layers.
+
+# VCS and CI
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# Docs and meta
+*.md
+LICENSE
+AGENTS.md
+CLAUDE.md
+REVIEW.md
+
+# Lint / tooling configs
+.editorconfig
+.yamllint.yml
+.markdownlint.json
+.gitleaks.toml
+.secretlintrc.json
+.trivy.yaml
+lefthook.yml
+Makefile
+
+# Tests and generated artifacts
+tests/
+test-results/
+megalinter-reports/
+output/
+artifacts/
+
+# Local / editor
+.idea/
+.vscode/
+.DS_Store
+.dde/
+__pycache__/
+*.py[cod]
+.ruff_cache/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+title = "gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+    description = "Allowlisted files"
+    paths = [
+    '''megalinter-reports''',
+    '''test-results''',
+    '''(.*?)gitleaks\.toml$''',
+    '''(?i)(.*?)(png|jpeg|jpg|gif|doc|docx|pdf|bin|xls|xlsx|pyc|zip)$''']

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+    "default": true,
+    "MD003": { "style": "atx" },
+    "MD007": { "indent": 2 },
+    "MD013": { "line_length": 400 },
+    "MD024": { "siblings_only": true },
+    "MD033": false,
+    "MD036": false
+}

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -1,0 +1,7 @@
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-preset-recommend"
+        }
+    ]
+}

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,0 +1,5 @@
+---
+scan:
+    skip-dirs:
+        - test-results/
+        - megalinter-reports/

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,42 @@
+# Code Review Guidelines
+
+## Scope
+
+In scope:
+
+- `Dockerfile` changes (stages, package sets, version ranges)
+- `requirements.txt` changes (ansible-core, mitogen, Python deps)
+- Test changes (`tests/` — unit, integration, security, performance, structure, upgrade)
+- CI/CD workflow changes
+- Renovate configuration updates
+- `Makefile` build/test targets
+
+Out of scope:
+
+- `test-results/` and `megalinter-reports/` — generated artifacts
+- Renovate dependency-only PRs (patch/minor with automerge enabled)
+- Generated changelog entries from release automation
+
+## Required checks
+
+- No secrets committed — no credentials, tokens, or keys in the image or build context
+- `hadolint` passes on the Dockerfile
+- yamllint passes
+- Container structure tests pass (`make structure-test`)
+- Security scans pass (gitleaks, secretlint, trivy)
+- Image runs as the non-root `ansible` user (UID/GID 1000)
+- Alpine packages use version ranges, never exact patch pins
+- Build tools stay in the builder stage and out of the production image
+
+## Severity levels
+
+| Level        | Meaning                                             | Merge impact       |
+| ------------ | --------------------------------------------------- | ------------------ |
+| Bug          | Incorrect behavior or broken contract               | Blocks merge       |
+| Nit          | Minor issue — suboptimal but not incorrect          | Non-blocking       |
+| Pre-existing | Issue present before this PR; flagged for awareness | No action required |
+
+## Skip
+
+- Renovate PRs with `automerge: true` (patch/minor) after CI passes
+- Documentation-only changes with no functional impact

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
 ---
 # Lefthook git hooks — run `lefthook install` once after cloning.
 # Tools without a system binary are installed on-demand via `npx --yes`.
-# System binaries: yamllint, gitleaks (>= v8.18 for `git --staged` subcommand),
+# System binaries: yamllint, gitleaks (>= v8.19 for `git --staged` subcommand),
 # hadolint, actionlint.
 #
 # Stack: Container image. Adapted from arillso/ansible.system

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,36 @@
+---
+# Lefthook git hooks — run `lefthook install` once after cloning.
+# Tools without a system binary are installed on-demand via `npx --yes`.
+# System binaries: yamllint, gitleaks (>= v8.18 for `git --staged` subcommand),
+# hadolint, actionlint.
+#
+# Stack: Container image. Adapted from arillso/ansible.system
+# (prettier+yamllint+markdownlint+gitleaks+actionlint), ansible-lint swapped
+# for hadolint since this repo ships a Dockerfile, not Ansible roles.
+
+pre-commit:
+    parallel: true
+    commands:
+        prettier:
+            glob: "*.{json,yml,yaml,md}"
+            run: npx --yes -- prettier --check {staged_files}
+        yamllint:
+            glob: "*.{yml,yaml}"
+            run: yamllint -c .yamllint.yml {staged_files}
+        markdownlint:
+            glob: "*.md"
+            run: npx --yes -- markdownlint-cli2 {staged_files}
+        hadolint:
+            glob: "Dockerfile*"
+            run: hadolint {staged_files}
+        actionlint:
+            glob: ".github/workflows/*.{yml,yaml}"
+            run: actionlint {staged_files}
+        gitleaks:
+            run: gitleaks git --staged --redact --no-banner
+
+pre-push:
+    parallel: true
+    commands:
+        gitleaks-full:
+            run: gitleaks git --redact --no-banner


### PR DESCRIPTION
Repo-standard audit (`/entwicklung:repo-standard`) flagged baseline files missing against the arillso standard. This PR adds the non-conditional + lefthook-conditional ones. Workflow-layout migration (event-focused `pull-request.yml`/`tag.yml` + `arillso/.github` reusables) and the gh-API settings drift are handled separately.

## Added

- **`lefthook.yml`** — pre-commit (prettier, yamllint, markdownlint, hadolint, actionlint, gitleaks), pre-push gitleaks-full. Adapted from `arillso/ansible.system`; `ansible-lint` swapped for `hadolint` since this is a container repo.
- **`.markdownlint.json` / `.gitleaks.toml` / `.secretlintrc.json` / `.trivy.yaml`** — lint/security configs the lefthook hooks reference (become Pflicht once lefthook exists).
- **`REVIEW.md`** — container-scoped review guidelines read by `ai-claude-review`.
- **`.dockerignore`** — trims build context to what the Dockerfile copies.

## Not in this PR

- Workflow layout (`ci.yml`/`security.yml`/`claude.yml`/`deploy.yml` → event-focused + reusables) — separate PR.
- gh-API settings (delete-on-merge, auto-merge, merge-commit off, token read-only, PVR, ruleset) — applied via API, no commit.