### PR TITLE
chore(ci): rename claude.yml to issue-comment.yml per event-focused convention

### DIFF
--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -1,5 +1,5 @@
 ---
-name: Claude
+name: Claude Code
 
 on:
     issue_comment:


### PR DESCRIPTION
## Summary

- Part 1 of the workflow-layout standard migration (audit via `/entwicklung:repo-standard`). The arillso standard names workflow files by trigger event, not by tool; `claude.yml` / `name: Claude` is a deprecated file name.
- `git mv claude.yml issue-comment.yml`, `name: Claude` → `name: Claude Code`. The job body (calling `arillso/.github` `ai-claude.yml` reusable) is unchanged.

## Not in this PR

- The CI core (`ci.yml` + `security.yml` + `deploy.yml`) entanglement — they share `workflow_call` and the `Test Summary` required-status-check context. That's a separate, higher-risk PR.
- `cleanup.yml` is already convention-compliant (function-named, uses a reusable) — left as is.

## Test plan

- [ ] CI green (rename only, no logic change)
- [ ] `issue-comment.yml` triggers unchanged on issue/PR comments