### PR TITLE
chore(ci): migrate workflows to event-focused layout

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,5 +1,7 @@
 ---
-name: Deployment
+name: Merge to Main
+run-name: |
+    Deployment by @${{ github.actor }}
 
 "on":
     push:
@@ -22,10 +24,10 @@ permissions:
     pull-requests: write
 
 jobs:
-    # Run CI and Security in parallel
+    # Re-run the full CI and security suites as a release gate before pushing.
     ci:
         name: Continuous Integration
-        uses: ./.github/workflows/ci.yml
+        uses: ./.github/workflows/pull-request.yml
         with:
             upload-sarif: false
         secrets: inherit
@@ -39,7 +41,7 @@ jobs:
 
     security:
         name: Security Scanning
-        uses: ./.github/workflows/security.yml
+        uses: ./.github/workflows/weekly-security.yml
         with:
             upload-sarif: false
         secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,13 +1,9 @@
 ---
-name: Continuous Integration
+name: Pull Request
+run-name: |
+    CI by @${{ github.actor }}
 
 "on":
-    push:
-        branches:
-            - main
-        paths-ignore:
-            - "**.md"
-            - "LICENSE"
     pull_request:
         branches:
             - main
@@ -15,7 +11,7 @@ name: Continuous Integration
             - "**.md"
             - "LICENSE"
     schedule:
-        - cron: "0 1 * * 3" # Wednesday at 1:00 UTC
+        - cron: "0 1 * * 3" # Wednesday at 1:00 UTC — weekly full CI run
     workflow_dispatch:
     workflow_call:
         inputs:

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -1,15 +1,12 @@
 ---
-name: Security Scanning
+name: Weekly Security Scan
+run-name: |
+    Security Scan by @${{ github.actor }}
 
 "on":
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - main
     schedule:
         - cron: "0 2 * * 1" # Weekly Monday 02:00 UTC
+    workflow_dispatch:
     workflow_call:
         inputs:
             upload-sarif:


### PR DESCRIPTION
## Summary

Part 2 of the workflow-layout standard migration (`/entwicklung:repo-standard`). Renames the file-centric workflows to the arillso event-focused convention — filename = trigger event, `name:` = activity noun, each gets a `run-name`.

| Before | After | Trigger change |
| --- | --- | --- |
| `ci.yml` / Continuous Integration | `pull-request.yml` / Pull Request | drops `push:main` (merge covers it); keeps `pull_request` + Wed schedule + `workflow_call` |
| `security.yml` / Security Scanning | `weekly-security.yml` / Weekly Security Scan | drops PR/push (PR security runs in pull-request.yml); keeps Mon schedule + `workflow_call` |
| `deploy.yml` / Deployment | `merge.yml` / Merge to Main | unchanged trigger (rolling date-tag release on push:main); internal gate now points at renamed reusables |

The `Test Summary` job name is unchanged, so the **required status check stays valid** — no ruleset update needed. `merge.yml` still re-runs the full CI + security suites as a release gate via `workflow_call`.

## Not in this PR

- `issue-comment.yml` (was `claude.yml`) — done in #500.
- `cleanup.yml` — already convention-compliant.
- Pre-existing shellcheck nits in the merge.yml release script (SC2034/SC2129) — untouched, out of scope for a rename.

## Test plan

- [ ] CI green on this PR (`Pull Request` workflow runs)
- [ ] `merge.yml` reusable gate resolves the renamed `pull-request.yml` / `weekly-security.yml` paths