### PR TITLE
fix(ci): avoid workflow injection via AI changelog output

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -235,14 +235,18 @@ jobs:
 
             - name: Update or create changelog entry
               id: update_changelog
+              env:
+                  RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+                  CHANGELOG_NOTES: ${{ steps.ai_notes.outputs.changelog_notes }}
               run: |
-                  tag="${{ steps.version.outputs.release_tag }}"
+                  tag="$RELEASE_TAG"
 
-                  # Read changelog notes from file to avoid backtick execution
+                  # Write the AI-generated notes via an env var, never via ${{ }}
+                  # interpolation — otherwise a delimiter or shell token in the
+                  # model output would be parsed by the workflow/shell instead of
+                  # treated as data.
                   changelog_file="/tmp/changelog_notes.txt"
-                  cat > "$changelog_file" << 'CHANGELOG_EOF'
-                  ${{ steps.ai_notes.outputs.changelog_notes }}
-                  CHANGELOG_EOF
+                  printf '%s\n' "$CHANGELOG_NOTES" > "$changelog_file"
 
                   # Check if changelog entry exists (independent of GitHub release)
                   if grep -q "^## \[${tag}\]" CHANGELOG.md; then


### PR DESCRIPTION
## Summary

Automated security review flagged a **HIGH** GitHub Actions injection in `merge.yml` (carried over from the old `deploy.yml`).

The changelog step wrote the OpenAI-generated notes into a shell heredoc via `${{ steps.ai_notes.outputs.changelog_notes }}`. GitHub Actions substitutes `${{ }}` **before** the shell runs, so a `CHANGELOG_EOF` delimiter or shell token in the model output would break out of the heredoc and be parsed as workflow/shell tokens.

Fix: pass the value through an `env:` var (`CHANGELOG_NOTES`) and write it with `printf '%s\n'` — the AI output is then always treated as data.

## Out of scope

- `aquasecurity/trivy-action@v0.36.0` unpinned (MEDIUM ×2): deliberate — `renovate.json` sets `pinDigests: false` for trivy-action (with hadolint/shellcheck). Org policy, not drift.
- 6 open code-scanning alerts (zlib/musl CVEs in the Alpine base): image-package CVEs, fixed by an Alpine/apk bump on rebuild — no code change here.

## Test plan

- [ ] CI green
- [ ] release step still writes the changelog correctly (printf from env var)