### PR TITLE
fix(ci): remove templated expression from merge.yml shell comment

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -241,10 +241,10 @@ jobs:
               run: |
                   tag="$RELEASE_TAG"
 
-                  # Write the AI-generated notes via an env var, never via ${{ }}
-                  # interpolation — otherwise a delimiter or shell token in the
-                  # model output would be parsed by the workflow/shell instead of
-                  # treated as data.
+                  # Write the AI-generated notes via the CHANGELOG_NOTES env
+                  # var, never via a templated expression — otherwise a
+                  # delimiter or shell token in the model output would be parsed
+                  # by the workflow/shell instead of treated as data.
                   changelog_file="/tmp/changelog_notes.txt"
                   printf '%s\n' "$CHANGELOG_NOTES" > "$changelog_file"
 


### PR DESCRIPTION
## Summary

Hotfix — `merge.yml` on `main` is invalid and every deploy fails at startup:

```
Invalid workflow file: .github/workflows/merge.yml (Line 241): An expression was expected
```

The injection fix (#502) left a literal `${{ }}` inside a `run:` **comment**. GitHub Actions evaluates expression syntax everywhere in a run block — comments included — so the empty `${{ }}` is parsed as an empty expression and the workflow fails to load (startup_failure). That blocked the rolling-release deploy (last successful image build: 2026-06-19), which is also why the code-scanning Trivy alerts went stale.

Fix: reword the comment without any expression syntax. No logic change.

## Test plan

- [ ] CI green
- [ ] `merge.yml` loads (no "expression was expected"); next push to main deploys + refreshes the Trivy scan