### PR TITLE
fix(ci): upload Trivy SARIF on schedule and push events

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -171,7 +171,10 @@ jobs:
                   severity: "CRITICAL,HIGH"
 
             - name: Upload Trivy scan results
-              if: ${{ inputs.upload-sarif != false }}
+              # Skip only when a workflow_call caller (merge.yml) passes
+              # upload-sarif: false. On pull_request / schedule there is no
+              # inputs context, so the bare check skipped the upload.
+              if: ${{ !(github.event_name == 'workflow_call' && inputs.upload-sarif == false) }}
               uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
               with:
                   sarif_file: "trivy-results.sarif"

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -51,7 +51,12 @@ jobs:
 
             - name: Upload Trivy scan results
               uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-              if: ${{ always() && inputs.upload-sarif != false }}
+              # Upload unless a caller explicitly opts out. On schedule /
+              # workflow_dispatch there is no `inputs` context, so the bare
+              # `inputs.upload-sarif != false` evaluated false and silently
+              # skipped the upload — leaving Code Scanning stale. Skip only
+              # when a workflow_call caller passes upload-sarif: false.
+              if: ${{ always() && !(github.event_name == 'workflow_call' && inputs.upload-sarif == false) }}
               with:
                   sarif_file: "trivy-results.sarif"
 


### PR DESCRIPTION
## Summary

The real reason the Code Scanning alerts are stale — **not** the image, not the deploy.

The SARIF upload step guarded with `if: ${{ inputs.upload-sarif != false }}`. On `schedule` / `workflow_dispatch` / `pull_request` there is **no `inputs` context**, so the expression evaluates false and the upload is **silently skipped**. The `default: true` only applies to a `workflow_call` with the input omitted — not to direct events.

Result: the last successful SARIF upload to `refs/heads/main` was **2026-04-12** (verified via `code-scanning/analyses`). Every scheduled/push security run since then ran Trivy but skipped the upload, so the zlib/musl CVE alerts froze at the April image state — no number of image rebuilds could clear them.

Fix: invert the guard — upload always, skip only when a `workflow_call` caller (`merge.yml`) explicitly passes `upload-sarif: false`. Applied to `weekly-security.yml` and `pull-request.yml`.

## After merge

A `workflow_dispatch` of `weekly-security.yml` will now actually upload, refreshing Code Scanning against the current image — the zlib/musl alerts should clear (fixes already in Alpine 3.24: zlib 1.3.2-r0, musl 1.2.6-r2).

## Test plan

- [ ] CI green
- [ ] dispatch weekly-security after merge → SARIF upload runs (not skipped) → alerts refresh