### PR TITLE
fix(ci): do not gate release on the changelog push

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -303,6 +303,8 @@ jobs:
                   rm -f "$changelog_file"
 
             - name: Commit changelog
+              env:
+                  RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
               run: |
                   if git diff --quiet CHANGELOG.md; then
                     echo "No changes to commit"
@@ -312,8 +314,17 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add CHANGELOG.md
-                  git commit -m "chore: update changelog for ${{ steps.version.outputs.release_tag }}"
-                  git push
+                  git commit -m "chore: update changelog for $RELEASE_TAG"
+
+                  # The branch ruleset blocks direct pushes by GITHUB_TOKEN.
+                  # The changelog commit is best-effort housekeeping — the
+                  # release itself (image build/push below) must not be gated
+                  # on it, so a rejected push only warns.
+                  if ! git push; then
+                    echo "::warning::Could not push the changelog commit to main \
+                  (branch ruleset). Continuing with build and release; the \
+                  release notes are still attached to the GitHub release."
+                  fi
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4


### PR DESCRIPTION
## Summary

With the branch ruleset **active**, the rolling-release deploy in `merge.yml` fails: the `Commit changelog` step pushes `CHANGELOG.md` straight to `main` as `github-actions[bot]`, the ruleset rejects it (`GH013: Changes must be made through a pull request`), and under `bash -e` the job dies **before** `Build and push` — so no image is produced.

Fix: make the changelog push **best-effort**. A rejected push emits a `::warning::` and the job continues; the image build/push and GitHub release (which carries the same notes) proceed. Tag passed via `env:` instead of `${{ }}`.

This lets the ruleset stay `active` (per repo standard) without the deploy bot fighting it.

## Test plan

- [ ] CI green
- [ ] After merge + ruleset re-enabled: a deploy run reaches Build and push even if the changelog push is rejected