### PR TITLE
ci(security): run security scan daily on this public repo

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -41,7 +41,7 @@ jobs:
 
     security:
         name: Security Scanning
-        uses: ./.github/workflows/weekly-security.yml
+        uses: ./.github/workflows/nightly-security.yml
         with:
             upload-sarif: false
         secrets: inherit

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -1,11 +1,11 @@
 ---
-name: Weekly Security Scan
+name: Nightly Security Scan
 run-name: |
     Security Scan by @${{ github.actor }}
 
 "on":
     schedule:
-        - cron: "0 2 * * 1" # Weekly Monday 02:00 UTC
+        - cron: "0 2 * * *" # Daily 02:00 UTC (public repo — Actions minutes are free)
     workflow_dispatch:
     workflow_call:
         inputs:
@@ -13,6 +13,10 @@ run-name: |
                 description: "Upload SARIF results to GitHub Code Scanning"
                 type: boolean
                 default: true
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
 
 permissions:
     contents: read


### PR DESCRIPTION
## Summary

Renames `weekly-security.yml` → `nightly-security.yml` ("Nightly Security Scan") and switches the schedule to a **daily** cron `0 2 * * *`. Adds the standard concurrency block. Updates the `merge.yml` reusable reference.

## Why

Per the arillso/sbaerlocher repo standard (visibility-based cadence rule): **public** repos get free GitHub Actions minutes, so the security scan runs daily; **private** repos run it weekly to save paid minutes. `docker.ansible` is public → daily.

## Test plan

- [ ] CI green