### PR TITLE
fix(docker): bump curl pin to 8.21.0-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	openssh-client-common=10.3_p1-r0 \
 	openssh-client-default=10.3_p1-r0 \
 	rsync=3.4.3-r1 \
-	curl=8.20.0-r1
+	curl=8.21.0-r0
 
 # Create virtual environment and install dependencies
 RUN	python3 -m venv /pipx/venvs/ansible && \
@@ -100,7 +100,7 @@ RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	python3=3.14.5-r0 \
 	bash=5.3.9-r1 \
 	git=2.54.0-r0 \
-	curl=8.20.0-r1 \
+	curl=8.21.0-r0 \
 	openssh-client-common=10.3_p1-r0 \
 	openssh-client-default=10.3_p1-r0 \
 	openssh-keygen=10.3_p1-r0 \


### PR DESCRIPTION
## Summary

The daily security scan build failed with `ERROR: unable to select packages: breaks: world[curl=8.20.0-r1]`. The pkg.arillso.io caching proxy has rotated `curl` from `8.20.0-r1` to `8.21.0-r0` for Alpine v3.24, dropping the old release.

Bumps the pinned `curl` version in both the builder and production `apk add` blocks. All other pins verified still present on the proxy.

Failing run: https://github.com/arillso/docker.ansible/actions/runs/28696825842

## Test plan

- [ ] CI security-scan build succeeds