### PR TITLE
fix(ci): warm apk pin cache nightly to keep pins resolvable

### DIFF
--- a/.github/scripts/warm-apk-pins.sh
+++ b/.github/scripts/warm-apk-pins.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# Description: Keep the pkg.arillso.io cache warm for the exact apk pins in the
+#              Dockerfile, and verify every pin is still resolvable.
+#
+#              The cache-evict sidecar in front of the proxy deletes *.apk files
+#              that nobody has read for 21 days (atime). A CI build does not read
+#              them: every workflow uses cache-from, so a cache-hit on the
+#              `RUN ... apk add ...` layer means the command never runs and no
+#              request reaches the proxy. That layer is only invalidated when
+#              Renovate bumps a pin inside it — so packages *without* a new
+#              upstream release are the ones that fall out of the cache first,
+#              and the next real build 404s against dl-cdn (Alpine rotates old
+#              -rN releases away). Fetching each pin here, outside Docker, keeps
+#              atime fresh and fails loudly while there is still time to react.
+#
+# Usage:       ./warm-apk-pins.sh [--list] [--alpine-version] [--dry-run]
+#                --list             print `name-version` for every pin, one per line
+#                --alpine-version   print the Alpine branch (e.g. v3.24)
+#                --dry-run          print the URLs that would be fetched
+#              With no flag, fetch every URL and report unresolvable pins.
+# Exit Code:   0 when every pin resolved, 1 otherwise
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKERFILE="${DOCKERFILE:-${SCRIPT_DIR}/../../Dockerfile}"
+PROXY="${PROXY:-https://pkg.arillso.io}"
+
+# Alpine's repository layout splits packages across main and community, and the
+# Dockerfile does not record which pin lives where. Trying both and accepting a
+# single hit is cheaper than maintaining that mapping by hand.
+BRANCHES=(main community)
+# merge.yml builds amd64 and arm64. Warming only the arch the nightly happens to
+# build would let the other one rot until the release build breaks.
+ARCHES=(x86_64 aarch64)
+
+# Derive the Alpine branch from the FROM pin rather than hardcoding it, so a
+# base image bump does not silently warm the wrong (still-populated) branch
+# while the pins the build actually needs expire.
+alpine_version() {
+    local version
+    version="$(sed -n 's/^FROM alpine:\([0-9][0-9]*\.[0-9][0-9]*\).*/v\1/p' "$DOCKERFILE" | head -n 1)"
+
+    if [ -z "$version" ]; then
+        echo "::error::Could not derive the Alpine version from ${DOCKERFILE} (expected a line like 'FROM alpine:3.24.1@sha256:...')" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$version"
+}
+
+# Extract every `name=version-rN` pin from the `apk add` blocks.
+#
+# Block-delimited on purpose: a repo-wide match for `name=value` also picks up
+# `ENV USER=ansible` and `ARG VCS_REF=""`, which would then be fetched as
+# packages. A block ends at the first line that does not continue the shell
+# command, which is why the trailing separator is stripped *before* matching —
+# the last pin of the production block ends in ` && \`, not ` \`, and a naive
+# pattern drops it (that is openssl, one silently missing pin).
+list_pins() {
+    awk '
+        /apk add --no-cache/ { in_block = 1; next }
+        !in_block { next }
+        {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]*&&[[:space:]]*\\$/, "", line)
+            sub(/[[:space:]]*\\$/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+
+            if (line ~ /^[a-z0-9][a-z0-9._+-]*=[0-9][^[:space:]]*$/) {
+                sub(/=/, "-", line)
+
+                # Five packages (curl, git, rsync, both openssh-client-*) are
+                # pinned in both the builder and the production block. Warming
+                # them once per block would double those requests for no gain.
+                if (!(line in seen)) {
+                    seen[line] = 1
+                    print line
+                }
+
+                next
+            }
+
+            in_block = 0
+        }
+    ' "$DOCKERFILE"
+}
+
+# Build the full URL set without touching the network, so the plan stays
+# testable offline.
+plan_urls() {
+    local alpine_version="$1"
+    local pin branch arch
+
+    while IFS= read -r pin; do
+        for branch in "${BRANCHES[@]}"; do
+            for arch in "${ARCHES[@]}"; do
+                printf '%s/alpine/%s/%s/%s/%s.apk\n' \
+                    "$PROXY" "$alpine_version" "$branch" "$arch" "$pin"
+            done
+        done
+    done
+}
+
+# GET, not HEAD: pkgproxy only writes to its cache when bytes are actually
+# streamed (rw.bytesWritten > 0), so a HEAD would report success on a miss
+# without populating anything. GET makes this self-healing for pins added since
+# the last run. Output is discarded — only the status code matters.
+fetch_pins() {
+    local alpine_version="$1"
+    local pin branch arch url failed=0 resolved
+
+    while IFS= read -r pin; do
+        for arch in "${ARCHES[@]}"; do
+            resolved=0
+
+            for branch in "${BRANCHES[@]}"; do
+                url="${PROXY}/alpine/${alpine_version}/${branch}/${arch}/${pin}.apk"
+
+                # No --show-error: main is always tried first, so every
+                # community-only package (helm, kubectl, …) would log a 404 per
+                # run even though the fallback succeeds. Real failures are
+                # reported below with the package and arch.
+                if curl --fail --silent --location \
+                    --max-time 60 --output /dev/null "$url"; then
+                    resolved=1
+                    break
+                fi
+            done
+
+            if [ "$resolved" -eq 0 ]; then
+                echo "::error::Pin ${pin} (${arch}) is not resolvable in any branch of Alpine ${alpine_version} — the next build of this image will fail" >&2
+                failed=1
+            fi
+        done
+    done
+
+    return "$failed"
+}
+
+main() {
+    local mode="${1:---fetch}"
+    local version pins
+
+    version="$(alpine_version)"
+
+    if [ "$mode" = "--alpine-version" ]; then
+        printf '%s\n' "$version"
+        return 0
+    fi
+
+    pins="$(list_pins)"
+
+    # An empty extraction would make every mode below a no-op that still exits
+    # green — the step would silently stop warming anything. Fail instead.
+    if [ -z "$pins" ]; then
+        echo "::error::No apk pins found in ${DOCKERFILE} — the extraction is broken or the Dockerfile changed shape" >&2
+        return 1
+    fi
+
+    case "$mode" in
+    --list)
+        printf '%s\n' "$pins"
+        ;;
+    --dry-run)
+        printf '%s\n' "$pins" | plan_urls "$version"
+        ;;
+    --fetch)
+        printf '%s\n' "$pins" | fetch_pins "$version"
+        ;;
+    *)
+        echo "::error::Unknown option: ${mode}" >&2
+        return 1
+        ;;
+    esac
+}
+
+main "$@"

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -33,6 +33,15 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+            # Runs before the build on purpose: the build uses cache-from, so a
+            # layer cache-hit means `apk add` never executes and never touches
+            # the proxy — which is exactly how pinned packages fall out of the
+            # 21-day atime eviction and 404 on the next real build. Fetching the
+            # pins directly keeps them warm and fails here, while there is still
+            # time to react, rather than in a release build.
+            - name: Warm apk pin cache
+              run: ./.github/scripts/warm-apk-pins.sh
+
             - name: Build image for scanning
               uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
               with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ tests/               # Unit, integration, security, performance tests
 ## Conventions
 
 - Alpine packages use exact pins (`pkg=version-rN`), resolved through the pkg.arillso.io caching proxy and bumped by Renovate (a customManager auto-detects every `apk add` pin via the repology datasource — no per-package markers)
+- The proxy is a pull-through cache, **not** an archive: its evict sidecar deletes `.apk` files nobody has read for 21 days, and Alpine rotates old `-rN` releases off dl-cdn. A pinned package that stops being fetched therefore becomes unbuildable. `.github/scripts/warm-apk-pins.sh` runs nightly to keep every pin read (and to fail loudly if one is already gone) — a normal CI build does not, because `cache-from` means a layer hit never executes `apk add`
 - Non-root user `ansible` (UID/GID 1000)
 - Mitogen enabled by default for performance
 - Multi-platform builds (amd64, arm64)
@@ -32,7 +33,8 @@ make release-check       # Pre-release validation
 
 ## Do Not
 
-- Use unpinned Alpine packages, or pin to a registry other than pkg.arillso.io (exact pins are only safe because the proxy retains old -rN releases; the renovate.json customManager keeps them current)
+- Use unpinned Alpine packages, or pin to a registry other than pkg.arillso.io (the renovate.json customManager keeps the pins current)
+- Remove the `Warm apk pin cache` step from `nightly-security.yml`, or make `warm-apk-pins.sh` tolerate an empty pin list or a failed fetch. It is the only thing that keeps pinned packages from being evicted from the proxy — silently degrading it reintroduces the exact failure it was written for, and the breakage surfaces weeks later in an unrelated build
 - Run as root in production
 - Disable Mitogen without reason
 - Skip security scans before release

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,10 @@ COPY requirements.txt /requirements.txt
 
 # Point apk at the pkg.arillso.io caching proxy for the exact pins below. This
 # is the BUILDER stage — it never ships, so the proxy URL stays local to the
-# build. The proxy keeps old -rN releases, which is what makes the pins
-# reproducible. Pins are auto-bumped by the customManager in
+# build. The proxy is a pull-through cache, not an archive — it evicts .apk
+# files unread for 21 days, and Alpine rotates old -rN releases off dl-cdn.
+# What keeps these pins resolvable is the nightly warm-apk-pins.sh step, not
+# the proxy itself. Pins are auto-bumped by the customManager in
 # .github/renovate.json (no per-package markers).
 RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	printf 'https://pkg.arillso.io/alpine/%s/main\nhttps://pkg.arillso.io/alpine/%s/community\n' \

--- a/tests/unit/test-warm-apk-pins.sh
+++ b/tests/unit/test-warm-apk-pins.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Description: Self-check for .github/scripts/warm-apk-pins.sh — verifies pin
+#              extraction and URL planning against the real Dockerfile. Both
+#              run offline; the network path is exercised by the nightly itself.
+# Usage:       ./test-warm-apk-pins.sh
+# Exit Code:   0 when all assertions pass, 1 otherwise
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WARM_SCRIPT="${REPO_ROOT}/.github/scripts/warm-apk-pins.sh"
+
+failures=0
+
+assert_eq() {
+    local expected="$1" actual="$2" message="$3"
+
+    if [ "$expected" = "$actual" ]; then
+        printf 'ok   %s\n' "$message"
+    else
+        printf 'FAIL %s\n     expected: %s\n     actual:   %s\n' \
+            "$message" "$expected" "$actual"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" message="$3"
+
+    if printf '%s\n' "$haystack" | grep -qxF "$needle"; then
+        printf 'ok   %s\n' "$message"
+    else
+        printf 'FAIL %s\n     missing: %s\n' "$message" "$needle"
+        failures=$((failures + 1))
+    fi
+}
+
+pins="$("$WARM_SCRIPT" --list)"
+urls="$("$WARM_SCRIPT" --dry-run)"
+version="$("$WARM_SCRIPT" --alpine-version)"
+
+# --- Extraction ------------------------------------------------------------
+
+# Both apk add blocks: 14 in builder + 15 in production = 29 raw, minus the 5
+# pinned in both (curl, git, rsync, openssh-client-common, openssh-client-default)
+# = 24 unique. A drop here means a pin stopped being warmed.
+assert_eq 24 "$(printf '%s\n' "$pins" | sort -u | wc -l | tr -d ' ')" \
+    'extracts 24 unique pins'
+
+# The script must emit each pin once. Without dedup the 5 shared pins are
+# fetched twice a night — harmless but pointless, and it desyncs the 96-URL
+# budget the workflow step is sized against.
+assert_eq "$(printf '%s\n' "$pins" | sort -u | wc -l | tr -d ' ')" \
+    "$(printf '%s\n' "$pins" | wc -l | tr -d ' ')" \
+    'pins are deduplicated'
+
+# curl is the package this whole mechanism exists for; openssl is the last pin
+# of the production block, which a naive `\`-only match drops.
+assert_contains "$pins" 'curl-8.21.0-r0' 'includes curl (the pin that broke)'
+assert_contains "$pins" 'openssl-3.5.7-r0' 'includes openssl (last pin in block)'
+assert_contains "$pins" 'python3-3.14.5-r0' 'includes python3'
+assert_contains "$pins" 'helm-3.19.0-r7' 'includes helm (community branch)'
+
+malformed="$(printf '%s\n' "$pins" | grep -vE '^[a-z0-9][a-z0-9._+-]*-[0-9][^[:space:]]*$' || true)"
+assert_eq '' "$malformed" 'every pin is well-formed'
+
+# ENV USER=ansible and ARG VCS_REF="" match a naive name=value pattern and would
+# be fetched as packages if the block boundaries ever stopped holding. Anchored
+# to the full name: a bare `^PIPX` prefix also matches the real `pipx` pin.
+leaked="$(printf '%s\n' "$pins" | grep -iE '^(USER|GROUP|UID|GID|VCS_REF|BUILD_DATE|ANSIBLE_VERSION|TARGETPLATFORM|PIPX_HOME|PIPX_BIN_DIR|PATH)-' || true)"
+assert_eq '' "$leaked" 'no ENV/ARG values leak into the pin list'
+
+# --- Version derivation ----------------------------------------------------
+
+# Bound to the current base image: a Renovate bump of the FROM pin needs this
+# line updated in the same PR. That coupling is the point — it proves the
+# version is really derived from the Dockerfile and not hardcoded.
+assert_eq 'v3.24' "$version" 'derives Alpine branch from the FROM pin'
+
+# --- URL planning ----------------------------------------------------------
+
+# 24 pins x 2 branches x 2 arches.
+assert_eq 96 "$(printf '%s\n' "$urls" | sort -u | wc -l | tr -d ' ')" \
+    'plans 96 unique URLs'
+
+assert_eq 48 "$(printf '%s\n' "$urls" | grep -c '/x86_64/')" 'covers x86_64'
+assert_eq 48 "$(printf '%s\n' "$urls" | grep -c '/aarch64/')" 'covers aarch64'
+assert_eq 48 "$(printf '%s\n' "$urls" | grep -c '/main/')" 'covers the main branch'
+assert_eq 48 "$(printf '%s\n' "$urls" | grep -c '/community/')" 'covers the community branch'
+
+assert_contains "$urls" \
+    'https://pkg.arillso.io/alpine/v3.24/main/x86_64/curl-8.21.0-r0.apk' \
+    'builds a complete, correct URL'
+
+malformed_urls="$(printf '%s\n' "$urls" | grep -vE '^https://pkg\.arillso\.io/alpine/v[0-9]+\.[0-9]+/(main|community)/(x86_64|aarch64)/[a-z0-9][a-z0-9._+-]*-[0-9][^[:space:]]*\.apk$' || true)"
+assert_eq '' "$malformed_urls" 'every URL is well-formed'
+
+# --- Failure modes ---------------------------------------------------------
+
+# An empty extraction must not exit green: a silently no-op warming step would
+# let the cache expire unnoticed, which is the failure this script prevents.
+empty_dockerfile="$(mktemp)"
+trap 'rm -f "$empty_dockerfile"' EXIT
+printf 'FROM alpine:3.24.1\nRUN echo no pins here\n' >"$empty_dockerfile"
+
+if DOCKERFILE="$empty_dockerfile" "$WARM_SCRIPT" --list >/dev/null 2>&1; then
+    printf 'FAIL exits non-zero when no pins are found\n'
+    failures=$((failures + 1))
+else
+    printf 'ok   exits non-zero when no pins are found\n'
+fi
+
+# A Dockerfile without a parseable FROM must fail rather than warm a guessed
+# branch.
+printf 'FROM ubuntu:24.04\nRUN apk add --no-cache curl=8.21.0-r0\n' >"$empty_dockerfile"
+
+if DOCKERFILE="$empty_dockerfile" "$WARM_SCRIPT" --alpine-version >/dev/null 2>&1; then
+    printf 'FAIL exits non-zero when the Alpine version is not derivable\n'
+    failures=$((failures + 1))
+else
+    printf 'ok   exits non-zero when the Alpine version is not derivable\n'
+fi
+
+# --- Result ----------------------------------------------------------------
+
+if [ "$failures" -gt 0 ]; then
+    printf '\n%s assertion(s) failed\n' "$failures"
+    exit 1
+fi
+
+printf '\nAll assertions passed\n'


### PR DESCRIPTION
## Summary

- Exact apk pins were only resolvable by luck: the caching proxy is a pull-through cache that evicts `.apk` files unread for 21 days, and Alpine rotates old `-rN` releases off dl-cdn. Because every workflow uses `cache-from`, a layer cache-hit means `apk add` never runs and never reads those files — so packages *without* a Renovate bump were evicted first. That is what broke `curl` in #519.
- Adds `.github/scripts/warm-apk-pins.sh`, run nightly before the scan build. It extracts the pins from both `apk add` blocks, derives the Alpine branch from the `FROM` line, and fetches each pin over `GET` outside Docker (96 requests: 24 pins x 2 branches x 2 arches). This keeps `atime` fresh and fails loudly while a pin is still recoverable.
- Corrects `AGENTS.md` and the Dockerfile comment, which both claimed the proxy retains old `-rN` releases — the exact belief behind the outage — and adds a `Do Not` entry against silently weakening the step.
- The proxy itself is unchanged: no config, no evict rules, no pin bumps.

## Test plan

- [ ] `tests/unit/test-warm-apk-pins.sh` — 18 assertions covering extraction (24 unique pins, dedup, no `ENV`/`ARG` leakage, `openssl` as the last pin in its block), version derivation, URL planning, and both hard-failure modes (empty pin list, underivable Alpine version). Runs offline.
- [ ] shellcheck, hadolint, actionlint, yamllint and gitleaks all pass (verified locally via containers; local hook binaries were unavailable).
- [ ] The network path could not be exercised locally — egress to `pkg.arillso.io` is blocked from the dev sandbox. **CI verifies it here**, and the step is deliberately strict rather than tolerant of a failed fetch.

Two assertions are version-bound (`v3.24`, `curl-8.21.0-r0`) and need a one-line update alongside a Renovate bump. That is intentional: they prove the version derivation and URL construction actually work.