### PR TITLE
refactor(deps): pin Alpine packages with >= lower bounds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,10 @@
     "customManagers": [
         {
             "customType": "regex",
-            "description": "Auto-detect every exact 'pkg=version-rN' apk pin in the Dockerfile and bump it via repology (Alpine alpine_3_24), including the -rN release suffix. No per-package comment markers needed — the apk add block structure is the anchor.",
+            "description": "Auto-detect every 'pkg>=version-rN' apk lower-bound pin in the Dockerfile and bump it via repology (Alpine alpine_3_24), including the -rN release suffix. No per-package comment markers needed — the apk add block structure is the anchor.",
             "managerFilePatterns": ["/(^|/)Dockerfile$/"],
             "matchStrings": [
-                "(?:apk add(?:[^\\n]*)?|\\\\)\\s+(?<depName>[a-z0-9][a-z0-9._-]*)=(?<currentValue>[a-zA-Z0-9._-]+)"
+                "(?:apk add(?:[^\\n]*)?|\\\\)\\s+\"?(?<depName>[a-z0-9][a-z0-9._-]*)>=(?<currentValue>[a-zA-Z0-9._-]+)"
             ],
             "depNameTemplate": "alpine_3_24/{{{depName}}}",
             "datasourceTemplate": "repology",

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+---
+# DL3018: hadolint flags `apk add pkg>=version` as "not pinned" because it only
+# recognizes exact `=`. The `>=` lower bounds here are a deliberate pin (see the
+# Dockerfile apk blocks and AGENTS.md): they tolerate Alpine's -rN rotation,
+# which exact pins do not. The bound is still enforced, so this is a false
+# positive for this repo's pinning policy.
+ignored:
+    - DL3018

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ tests/               # Unit, integration, security, performance tests
 
 ## Conventions
 
-- Alpine packages use exact pins (`pkg=version-rN`), resolved through the pkg.arillso.io caching proxy and bumped by Renovate (a customManager auto-detects every `apk add` pin via the repology datasource — no per-package markers)
+- Alpine packages use `>=` lower-bound pins (`pkg>=version-rN`), resolved through the pkg.arillso.io caching proxy and bumped by Renovate (a customManager auto-detects every `apk add` pin via the repology datasource — no per-package markers). Lower bounds tolerate Alpine's -rN rotation: the proxy is a pull-through cache, not an archive, so exact pins break on rebuild once an old -rN drops from dl-cdn
 - Non-root user `ansible` (UID/GID 1000)
 - Mitogen enabled by default for performance
 - Multi-platform builds (amd64, arm64)
@@ -32,7 +32,9 @@ make release-check       # Pre-release validation
 
 ## Do Not
 
-- Use unpinned Alpine packages, or pin to a registry other than pkg.arillso.io (exact pins are only safe because the proxy retains old -rN releases; the renovate.json customManager keeps them current)
+- Use unpinned Alpine packages, or pin to a registry other than pkg.arillso.io (the renovate.json customManager keeps the lower bounds current)
+- Replace the `>=` lower bounds with exact `=` pins, or drop the lower bound entirely — `>=` is deliberate so Alpine's -rN rotation cannot break the build
+- Add an upper bound to the Alpine pins — the earlier upper-bound experiment (py3-pip, python3-dev) just recreated the drift pain from the other direction
 - Run as root in production
 - Disable Mitogen without reason
 - Skip security scans before release

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,29 +40,32 @@ WORKDIR /home
 # Copy dependencies
 COPY requirements.txt /requirements.txt
 
-# Point apk at the pkg.arillso.io caching proxy for the exact pins below. This
-# is the BUILDER stage — it never ships, so the proxy URL stays local to the
-# build. The proxy keeps old -rN releases, which is what makes the pins
-# reproducible. Pins are auto-bumped by the customManager in
-# .github/renovate.json (no per-package markers).
+# Point apk at the pkg.arillso.io caching proxy for the lower-bound pins below.
+# This is the BUILDER stage — it never ships, so the proxy URL stays local to
+# the build. Pins use `>=` lower bounds, not exact `=`: the proxy is a
+# pull-through cache, not an archive, so once Alpine rotates an old -rN out of
+# dl-cdn an exact pin breaks on rebuild. `>=` lets apk take the current -rN and
+# tolerates that rotation, while Renovate still lifts the lower bound and the
+# text change invalidates the cache. The customManager in .github/renovate.json
+# auto-detects every pin (no per-package markers).
 RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	printf 'https://pkg.arillso.io/alpine/%s/main\nhttps://pkg.arillso.io/alpine/%s/community\n' \
 		"$alpine_minor" "$alpine_minor" > /etc/apk/repositories && \
 	apk add --no-cache \
-	py3-pip=26.1.2-r0 \
-	pipx=1.14.0-r0 \
-	ca-certificates=20260611-r0 \
-	git=2.54.0-r0 \
-	gcc=15.2.0-r5 \
-	libffi-dev=3.5.2-r1 \
-	python3-dev=3.14.5-r0 \
-	make=4.4.1-r4 \
-	musl-dev=1.2.6-r2 \
-	build-base=0.5-r4 \
-	openssh-client-common=10.3_p1-r0 \
-	openssh-client-default=10.3_p1-r0 \
-	rsync=3.4.3-r1 \
-	curl=8.21.0-r0
+	"py3-pip>=26.1.2-r0" \
+	"pipx>=1.14.0-r0" \
+	"ca-certificates>=20260611-r0" \
+	"git>=2.54.0-r0" \
+	"gcc>=15.2.0-r5" \
+	"libffi-dev>=3.5.2-r1" \
+	"python3-dev>=3.14.5-r0" \
+	"make>=4.4.1-r4" \
+	"musl-dev>=1.2.6-r2" \
+	"build-base>=0.5-r4" \
+	"openssh-client-common>=10.3_p1-r0" \
+	"openssh-client-default>=10.3_p1-r0" \
+	"rsync>=3.4.3-r1" \
+	"curl>=8.21.0-r0"
 
 # Create virtual environment and install dependencies
 RUN	python3 -m venv /pipx/venvs/ansible && \
@@ -88,30 +91,33 @@ ENV USER=ansible \
 
 WORKDIR /home/ansible
 
-# Install all runtime dependencies in a single layer. Exact apk pins
-# auto-bumped by Renovate (see .github/renovate.json), resolved through the
-# pkg.arillso.io proxy configured inline in this RUN, then reset to the
-# public mirrors so the shipped image does not depend on the proxy.
+# Install all runtime dependencies in a single layer. apk pins use `>=` lower
+# bounds (not exact `=`) auto-bumped by Renovate (see .github/renovate.json),
+# resolved through the pkg.arillso.io proxy configured inline in this RUN, then
+# reset to the public mirrors so the shipped image does not depend on the proxy.
+# The proxy is a pull-through cache, not an archive: an exact pin breaks on
+# rebuild once Alpine rotates an old -rN out of dl-cdn, whereas `>=` lets apk
+# take the current -rN and tolerates that rotation.
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	printf 'https://pkg.arillso.io/alpine/%s/main\nhttps://pkg.arillso.io/alpine/%s/community\n' \
 		"$alpine_minor" "$alpine_minor" > /etc/apk/repositories && \
 	apk add --no-cache \
-	python3=3.14.5-r0 \
-	bash=5.3.9-r1 \
-	git=2.54.0-r0 \
-	curl=8.21.0-r0 \
-	openssh-client-common=10.3_p1-r0 \
-	openssh-client-default=10.3_p1-r0 \
-	openssh-keygen=10.3_p1-r0 \
-	sshpass=1.10-r0 \
-	rsync=3.4.3-r1 \
-	kubectl=1.36.1-r0 \
-	helm=3.19.0-r7 \
-	kustomize=5.8.1-r2 \
-	jq=1.8.1-r0 \
-	gnupg=2.4.9-r1 \
-	openssl=3.5.7-r0 && \
+	"python3>=3.14.5-r0" \
+	"bash>=5.3.9-r1" \
+	"git>=2.54.0-r0" \
+	"curl>=8.21.0-r0" \
+	"openssh-client-common>=10.3_p1-r0" \
+	"openssh-client-default>=10.3_p1-r0" \
+	"openssh-keygen>=10.3_p1-r0" \
+	"sshpass>=1.10-r0" \
+	"rsync>=3.4.3-r1" \
+	"kubectl>=1.36.1-r0" \
+	"helm>=3.19.0-r7" \
+	"kustomize>=5.8.1-r2" \
+	"jq>=1.8.1-r0" \
+	"gnupg>=2.4.9-r1" \
+	"openssl>=3.5.7-r0" && \
 	# Reset to the public Alpine mirrors so the SHIPPED image does not depend
 	# on the private build-time proxy — downstream `apk add` uses dl-cdn.
 	printf 'https://dl-cdn.alpinelinux.org/alpine/%s/main\nhttps://dl-cdn.alpinelinux.org/alpine/%s/community\n' \

--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -18,14 +18,17 @@ commandTests:
           # an unanchored substring of `helm version --short` ("v3.19.0+g...").
           # extractVersion strips the v prefix from the helm/helm tags.
           # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-          - "3.19.0"
+          # Major-prefix only: under `>=` apk installs the current patch, so an
+          # exact patch substring breaks on drift. A helm 4 jump still fails "3.".
+          - "3."
 
     - name: "Check kustomize Version"
       command: "kustomize"
       args: ["version"]
       expectedOutput:
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/v(?<version>.*)$
-          - "5.8.1"
+          # Major-prefix only: `>=` installs the current patch (see helm above).
+          - "5."
 
     # Shell Tools & Utilities
     - name: "Check Bash Version"
@@ -42,7 +45,8 @@ commandTests:
           # substring. extractVersion strips the jq- prefix from jqlang/jq tags
           # so Renovate compares plain semver.
           # renovate: datasource=github-releases depName=jqlang/jq extractVersion=^jq-(?<version>.*)$
-          - "1.8.1"
+          # Major-prefix only: `>=` installs the current patch (see helm above).
+          - "1."
 
     - name: "Check sshpass Availability"
       command: "which"
@@ -59,7 +63,8 @@ commandTests:
           # never updated. `openssl version` prints "OpenSSL 3.5.7 ..." and CST
           # matches the bare version as a substring.
           # renovate: datasource=repology depName=openssl versioning=loose
-          - "3.5.7"
+          # Major-prefix only: `>=` installs the current patch (see helm above).
+          - "3."
 
     - name: "Check Git Version"
       command: "git"


### PR DESCRIPTION
## Summary

- Switch all 29 apk pins in both build stages from exact `pkg=version-rN` to `pkg>=version-rN`. The `pkg.arillso.io` proxy is a pull-through cache, not an archive, so an exact pin breaks on rebuild once Alpine rotates an old `-rN` out of `dl-cdn`; lower bounds tolerate that rotation and also avoid the earlier upper-bound drift.
- Quote each specifier so shellcheck does not read `>` as a redirection; widen the Renovate customManager regex to match the `>=` format; relax the four container-structure-test asserts to major-version prefixes; add `.hadolint.yaml` ignoring DL3018, which does not recognize `>=` as a pin.

## Test plan

- [ ] CI build resolves all `>=` pins through the proxy (verified locally: full `apk add` of both stages resolved and installed).
- [ ] hadolint, gitleaks, yamllint, markdownlint, prettier green (verified locally via pre-commit).
- [ ] container-structure-test passes against the built image.
- [ ] Renovate dry-run captures 29 pins with the new regex.