### PR TITLE
fix(security): gate builds on fixable critical and high CVEs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@ REVIEW.md
 .markdownlint.json
 .gitleaks.toml
 .secretlintrc.json
+.trivyignore
 lefthook.yml
 Makefile
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,6 @@ REVIEW.md
 .markdownlint.json
 .gitleaks.toml
 .secretlintrc.json
-.trivy.yaml
 lefthook.yml
 Makefile
 

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -45,13 +45,15 @@ jobs:
                   provenance: false
                   sbom: false
 
-            - name: Run Trivy vulnerability scanner
+            # Reporting step: never gates, always produces SARIF for upload.
+            - name: Run Trivy vulnerability scanner (report)
               uses: aquasecurity/trivy-action@v0.36.0
               with:
                   image-ref: "ansible:scan"
                   format: "sarif"
                   output: "trivy-results.sarif"
                   severity: "CRITICAL,HIGH"
+                  exit-code: "0"
 
             - name: Upload Trivy scan results
               uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
@@ -63,6 +65,17 @@ jobs:
               if: ${{ always() && !(github.event_name == 'workflow_call' && inputs.upload-sarif == false) }}
               with:
                   sarif_file: "trivy-results.sarif"
+
+            # Gating step: fails the job on fixable CRITICAL/HIGH findings.
+            # Runs after the upload so results reach Code Scanning either way.
+            - name: Run Trivy vulnerability scanner (gate)
+              uses: aquasecurity/trivy-action@v0.36.0
+              with:
+                  image-ref: "ansible:scan"
+                  format: "table"
+                  severity: "CRITICAL,HIGH"
+                  ignore-unfixed: true
+                  exit-code: "1"
 
     secrets:
         name: Secret Scanning

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -68,6 +68,8 @@ jobs:
 
             # Gating step: fails the job on fixable CRITICAL/HIGH findings.
             # Runs after the upload so results reach Code Scanning either way.
+            # Only the gate honours .trivyignore; the reporting step above keeps
+            # sending every finding to Code Scanning.
             - name: Run Trivy vulnerability scanner (gate)
               uses: aquasecurity/trivy-action@v0.36.0
               with:
@@ -75,6 +77,7 @@ jobs:
                   format: "table"
                   severity: "CRITICAL,HIGH"
                   ignore-unfixed: true
+                  trivyignores: ".trivyignore"
                   exit-code: "1"
 
     secrets:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,7 +77,7 @@ jobs:
                   dockerfile: Dockerfile
 
             - name: Lint shell scripts
-              run: shellcheck tests/**/*.sh .github/scripts/**/*.sh
+              run: shellcheck tests/**/*.sh .github/scripts/**/*.sh build/*.sh
 
     prepare:
         name: Prepare
@@ -204,6 +204,8 @@ jobs:
 
             # Gating step: fails the job on fixable CRITICAL/HIGH findings.
             # Runs after the upload so results reach Code Scanning either way.
+            # Only the gate honours .trivyignore; the reporting step above keeps
+            # sending every finding to Code Scanning.
             - name: Trivy Vulnerability Scanner (gate)
               uses: aquasecurity/trivy-action@v0.36.0
               with:
@@ -211,6 +213,7 @@ jobs:
                   format: "table"
                   severity: "CRITICAL,HIGH"
                   ignore-unfixed: true
+                  trivyignores: ".trivyignore"
                   exit-code: "1"
 
     performance-test:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -183,22 +183,35 @@ jobs:
                   docker run --rm -v "$GITHUB_WORKSPACE/tests/security:/tests" ansible:test \
                   bash /tests/container-hardening.sh | tee test-results/security-check.log
 
-            - name: Trivy Vulnerability Scanner
+            # Reporting step: never gates, always produces SARIF for upload.
+            - name: Trivy Vulnerability Scanner (report)
               uses: aquasecurity/trivy-action@v0.36.0
               with:
                   image-ref: "ansible:test"
                   format: "sarif"
                   output: "trivy-results.sarif"
                   severity: "CRITICAL,HIGH"
+                  exit-code: "0"
 
             - name: Upload Trivy scan results
               # Skip only when a workflow_call caller (merge.yml) passes
               # upload-sarif: false. On pull_request / schedule there is no
               # inputs context, so the bare check skipped the upload.
-              if: ${{ !(github.event_name == 'workflow_call' && inputs.upload-sarif == false) }}
+              if: ${{ always() && !(github.event_name == 'workflow_call' && inputs.upload-sarif == false) }}
               uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
               with:
                   sarif_file: "trivy-results.sarif"
+
+            # Gating step: fails the job on fixable CRITICAL/HIGH findings.
+            # Runs after the upload so results reach Code Scanning either way.
+            - name: Trivy Vulnerability Scanner (gate)
+              uses: aquasecurity/trivy-action@v0.36.0
+              with:
+                  image-ref: "ansible:test"
+                  format: "table"
+                  severity: "CRITICAL,HIGH"
+                  ignore-unfixed: true
+                  exit-code: "1"
 
     performance-test:
         name: Performance Test

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,5 +1,0 @@
----
-scan:
-    skip-dirs:
-        - test-results/
-        - megalinter-reports/

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,20 @@
+# CVE-2025-47273 — setuptools PackageIndex path traversal.
+#
+# Trivy reports setuptools 70.3.0 against this image, but no setuptools code is
+# in it: `find <pip>/_vendor -iname '*setuptools*'` comes back empty, and the
+# venv's site-packages has no setuptools either. pip absorbed the pkg_resources
+# module into its _vendor tree, rewrote its imports to pip._vendor.packaging and
+# pip._internal.utils._jaraco_text, and kept crediting setuptools for it in
+# bom.cdx.json — which is where this finding comes from, carrying a BOMRef and
+# no file path.
+#
+# The advisory targets PackageIndex, which that module does not contain: pip
+# never vendored the part of setuptools the CVE is about. Upgrading cannot clear
+# it either, since every pip release up to 26.2.1 carries the same stale credit.
+#
+# Only the gating scans read this file; the reporting scans still send every
+# finding to Code Scanning.
+#
+# Revisit when pip drops the setuptools entry from its SBOM, or when a finding
+# appears that names an actual file in the image.
+CVE-2025-47273

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,16 +78,35 @@ RUN	python3 -m venv /pipx/venvs/ansible && \
 	# Cleanup
 	rm -rf /var/cache/apk/* /tmp/*
 
+# Replace the msgpack copy pip vendors (GHSA-6v7p-g79w-8964). The script carries
+# the reasoning; it runs in the builder stage, so it never ships.
+COPY build/vendorfix-msgpack.sh /tmp/vendorfix-msgpack.sh
+RUN sh /tmp/vendorfix-msgpack.sh /pipx/venvs/ansible && \
+	rm -f /tmp/vendorfix-msgpack.sh
+
 ##############################################
 # Production Stage
 ##############################################
 FROM base AS production
 
-# User parameters
-ENV USER=ansible \
-	GROUP=ansible \
-	UID=1000 \
-	GID=1000
+# User parameters. The ids are defined here as ARGs and mirrored into ENV below,
+# because `USER` further down has to be written literally: hadolint reads that
+# instruction statically and rejects ${UID} as non-numeric (DL3066) just as it
+# rejects ${USER}.
+#
+# So overriding --build-arg UID/GID moves the account and the ENV, but not that
+# literal, and the image would run as a uid it did not create. Change both
+# together; the structure test asserts the metadata user and these environment
+# variables, so a mismatch fails there.
+ARG USER=ansible
+ARG GROUP=ansible
+ARG UID=1000
+ARG GID=1000
+
+ENV USER=${USER} \
+	GROUP=${GROUP} \
+	UID=${UID} \
+	GID=${GID}
 
 WORKDIR /home/ansible
 
@@ -154,12 +173,14 @@ RUN mkdir -p /etc/ansible && \
 	echo 'pipelining = True' >> /etc/ansible/ansible.cfg && \
 	rm -rf /tmp/*
 
-# Use non-root user
-USER ${USER}
+# Use non-root user, numeric so a host can resolve the id without reading the
+# image's passwd file. Literal rather than ${UID}:${GID} — see the ARG block.
+USER 1000:1000
 ENV ANSIBLE_FORCE_COLOR=True
 
 # Default command
 CMD ["ansible-playbook", "--version"]
 
 # Healthcheck to verify Ansible functionality
-HEALTHCHECK --interval=30s --timeout=10s CMD ansible --version || exit 1
+HEALTHCHECK --interval=30s --timeout=10s \
+	CMD ["/bin/sh", "-c", "ansible --version || exit 1"]

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ security-test: ansible-build ## Run comprehensive security checks
 	@docker run --rm -v "$(PROJECT_DIR)/tests/security:/tests" ansible:latest bash /tests/container-hardening.sh
 	@echo ""
 	@echo "2. Trivy vulnerability scan..."
-	@docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$(PROJECT_DIR)/test-results:/results" aquasec/trivy:0.68.2 image --exit-code 0 --severity HIGH,CRITICAL --format table -o /results/trivy-results.txt ansible:latest || (echo "Trivy scan found issues - check test-results/trivy-results.txt"; exit 0)
+	@docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$(PROJECT_DIR)/test-results:/results" aquasec/trivy:0.68.2 image --exit-code 1 --ignore-unfixed --severity HIGH,CRITICAL --format table -o /results/trivy-results.txt ansible:latest || (echo "Trivy scan found fixable HIGH/CRITICAL issues - check test-results/trivy-results.txt"; exit 1)
 	@echo ""
 	@echo "3. User permissions check..."
 	@docker run --rm ansible:latest id | grep "uid=1000(ansible) gid=1000(ansible)" && echo "Non-root user correctly configured"

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ security-test: ansible-build ## Run comprehensive security checks
 	@docker run --rm -v "$(PROJECT_DIR)/tests/security:/tests" ansible:latest bash /tests/container-hardening.sh
 	@echo ""
 	@echo "2. Trivy vulnerability scan..."
-	@docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$(PROJECT_DIR)/test-results:/results" aquasec/trivy:0.68.2 image --exit-code 1 --ignore-unfixed --severity HIGH,CRITICAL --format table -o /results/trivy-results.txt ansible:latest || (echo "Trivy scan found fixable HIGH/CRITICAL issues - check test-results/trivy-results.txt"; exit 1)
+	@docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$(PROJECT_DIR)/test-results:/results" -v "$(PROJECT_DIR)/.trivyignore:/.trivyignore:ro" aquasec/trivy:0.68.2 image --exit-code 1 --ignore-unfixed --ignorefile /.trivyignore --severity HIGH,CRITICAL --format table -o /results/trivy-results.txt ansible:latest || (echo "Trivy scan found fixable HIGH/CRITICAL issues - check test-results/trivy-results.txt"; exit 1)
 	@echo ""
 	@echo "3. User permissions check..."
 	@docker run --rm ansible:latest id | grep "uid=1000(ansible) gid=1000(ansible)" && echo "Non-root user correctly configured"

--- a/build/vendorfix-msgpack.sh
+++ b/build/vendorfix-msgpack.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Replace the msgpack copy pip vendors, for GHSA-6v7p-g79w-8964.
+#
+# The affected Unpacker lives in pip/_vendor/msgpack/fallback.py, which really is
+# in the image. msgpack is not a venv package, so requirements.txt cannot reach
+# it, and every pip release up to 26.2.1 vendors the same 1.1.2, so bumping pip
+# does not help either.
+#
+# vendor.txt and bom.cdx.json are pip's own record of what it bundles. Both are
+# rewritten so neither a human nor a scanner still reads 1.1.2; Trivy takes the
+# version from the SBOM, whose findings carry a BOMRef and no file path. Nothing
+# in pip reads either file at runtime.
+#
+# The other finding Trivy reports against this tree, CVE-2025-47273 against
+# setuptools, is a stale SBOM credit rather than code — see .trivyignore.
+set -eu
+
+venv="${1:?usage: vendorfix-msgpack.sh <venv-dir>}"
+
+vendor_dir="$(echo "$venv"/lib/python*/site-packages/pip/_vendor)"
+[ -d "$vendor_dir" ] || {
+    echo "vendorfix: no pip/_vendor under $venv" >&2
+    exit 1
+}
+
+stage=/tmp/vendorfix
+"$venv/bin/pip" install --no-cache-dir --target "$stage" "msgpack>=1.2.1"
+[ -d "$stage/msgpack" ] || {
+    echo "vendorfix: pip install produced no msgpack" >&2
+    exit 1
+}
+
+version="$(sed -n 's/^Version: //p;T;q' "$stage"/msgpack-*.dist-info/METADATA)"
+[ -n "$version" ] || {
+    echo "vendorfix: no Version in msgpack METADATA" >&2
+    exit 1
+}
+
+rm -rf "${vendor_dir:?}/msgpack"
+cp -a "$stage/msgpack" "$vendor_dir/msgpack"
+
+# pip's resolver imports both on every run; fail the build, not the user's first
+# `pip install`, if the swap left the tree unimportable.
+"$venv/bin/python" -c "from pip._vendor import msgpack, pkg_resources"
+
+sed -i "s/^msgpack==.*/msgpack==$version/" "$vendor_dir/vendor.txt"
+grep -q "msgpack==$version" "$vendor_dir/vendor.txt"
+
+"$venv/bin/python" - "$vendor_dir/bom.cdx.json" "$version" <<'PY'
+import json
+import sys
+
+path, version = sys.argv[1], sys.argv[2]
+bom = json.load(open(path))
+
+patched = 0
+for component in bom.get("components", []):
+    if component.get("name") != "msgpack":
+        continue
+    component["version"] = version
+    for key in ("purl", "bom-ref"):
+        if key in component:
+            component[key] = "pkg:pypi/msgpack@" + version
+    patched += 1
+
+if not patched:
+    sys.exit("vendorfix: no msgpack component in SBOM")
+
+json.dump(bom, open(path, "w"), indent=2)
+PY
+
+rm -rf "$stage"

--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -296,4 +296,8 @@ metadataTest:
           value: "True"
     cmd: ["ansible-playbook", "--version"]
     workdir: "/home/ansible"
-    user: "ansible"
+    # Numeric, matching the literal `USER 1000:1000` in the Dockerfile, which is
+    # spelled that way for hadolint DL3066. Together with the UID/GID assertions
+    # above this catches the literal drifting from the ARG defaults. The account
+    # is unchanged — the command tests above still assert whoami is `ansible`.
+    user: "1000:1000"


### PR DESCRIPTION
## Summary

- Trivy never gated: both workflow steps omitted `exit-code`, so the default `0` let images with known CRITICAL/HIGH CVEs publish on a green pipeline. `severity:` only filters what gets reported.
- Each workflow now has a non-blocking reporting step (`exit-code: "0"`) feeding the SARIF upload, plus a gating step with `exit-code: "1"` and `ignore-unfixed: true` that runs after the upload, so results reach Code Scanning even when the gate fails.
- `Makefile` was non-blocking twice over (`--exit-code 0 ... || exit 0`); it now gates on fixable HIGH/CRITICAL findings.
- Dropped `.trivy.yaml`: it was never loaded (no `trivy-config:`, no `TRIVY_CONFIG`, no `--config`) and its `skip-dirs` targeted repo report folders, which do not apply to image scans.

Turning the gate on surfaced two HIGH findings against pip's own `_vendor` tree. They look alike but need opposite treatment:

- **GHSA-6v7p-g79w-8964, msgpack 1.1.2 — real code.** The affected Unpacker is in `pip/_vendor/msgpack/fallback.py`, so `build/vendorfix-msgpack.sh` replaces it with 1.2.1 and syncs pip's `vendor.txt` and `bom.cdx.json`. msgpack is not a venv package, so `requirements.txt` cannot reach it, and every pip release up to 26.2.1 vendors the same 1.1.2.
- **CVE-2025-47273, setuptools 70.3.0 — a stale SBOM credit**, recorded in `.trivyignore` instead. No setuptools code is in the image: searching `_vendor` for it comes back empty and the venv has none. pip absorbed `pkg_resources`, rewrote its imports to `pip._vendor.packaging` and `pip._internal.utils._jaraco_text`, and kept crediting setuptools in `bom.cdx.json`. The advisory targets `PackageIndex`, which that module does not contain.

Only the gating scans read `.trivyignore`; the reporting steps are untouched, so Code Scanning still receives every finding.

Two hadolint findings that predate this branch are also fixed, because the Lint job runs at `failure-threshold: info` and blocked every downstream job: `USER` is numeric (DL3066) and `HEALTHCHECK` uses JSON notation (DL3025). Both reproduce against an unmodified `main`.

## Test plan

- [x] Gate exits 0 on the built image with the ignore file; without it only setuptools is reported, so msgpack is genuinely gone rather than muted.
- [x] `pip._vendor.pkg_resources` and `msgpack` import, `pip list` and a dry-run install work — the resolver imports `pkg_resources` on every run.
- [x] `ansible localhost -m ping` returns pong over mitogen; runtime user is `uid=1000(ansible)`.
- [x] The build script is absent from the shipped image.
- [x] hadolint clean at `--failure-threshold info`, shellcheck and actionlint clean, structure tests 40/40.
- [ ] CI green on this PR.
