### PR TITLE
fix(tests): let security and upgrade tests report failures

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -179,8 +179,9 @@ jobs:
             - name: Run Security Checks
               run: |
                   mkdir -p test-results
+                  set -o pipefail
                   docker run --rm -v "$GITHUB_WORKSPACE/tests/security:/tests" ansible:test \
-                  bash -c "bash /tests/container-hardening.sh || echo 'Security check returned warnings'" | tee test-results/security-check.log
+                  bash /tests/container-hardening.sh | tee test-results/security-check.log
 
             - name: Trivy Vulnerability Scanner
               uses: aquasecurity/trivy-action@v0.36.0
@@ -348,7 +349,7 @@ jobs:
 
             - name: Run Upgrade Tests
               run: |
-                  ANSIBLE_IMAGE="ansible:test" bash tests/upgrade/test-upgrade.sh || (echo "Some upgrade tests failed, but continuing"; exit 0)
+                  ANSIBLE_IMAGE="ansible:test" bash tests/upgrade/test-upgrade.sh
 
     test-summary:
         name: Test Summary

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ security-test: ansible-build ## Run comprehensive security checks
 	@echo "=== Running Security Tests ==="
 	@mkdir -p $(PROJECT_DIR)/test-results
 	@echo "1. Container hardening checks..."
-	@docker run --rm -v "$(PROJECT_DIR)/tests/security:/tests" ansible:latest bash -c "bash /tests/container-hardening.sh" || (echo "Security check warnings found"; exit 0)
+	@docker run --rm -v "$(PROJECT_DIR)/tests/security:/tests" ansible:latest bash /tests/container-hardening.sh
 	@echo ""
 	@echo "2. Trivy vulnerability scan..."
 	@docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$(PROJECT_DIR)/test-results:/results" aquasec/trivy:0.68.2 image --exit-code 0 --severity HIGH,CRITICAL --format table -o /results/trivy-results.txt ansible:latest || (echo "Trivy scan found issues - check test-results/trivy-results.txt"; exit 0)
@@ -125,7 +125,7 @@ unit-test: ansible-build ## Run unit tests with Python
 
 upgrade-test: ansible-build ## Test the container's ability to upgrade
 	@echo "Testing upgrade capability..."
-	@bash $(PROJECT_DIR)/tests/upgrade/test-upgrade.sh || (echo "Some upgrade tests failed, but continuing"; exit 0)
+	@bash $(PROJECT_DIR)/tests/upgrade/test-upgrade.sh
 
 comprehensive-test: test-quick structure-test security-test performance-test integration-test unit-test upgrade-test ## Run all tests in order
 	@echo ""

--- a/tests/security/container-hardening.sh
+++ b/tests/security/container-hardening.sh
@@ -2,6 +2,10 @@
 # Safer security check that works for non-root users
 set -e
 
+# Hard violations set this flag and make the script exit non-zero at the end.
+# Soft findings stay warnings so the whole report is always printed first.
+hard_failure=0
+
 echo "==== Container Security Hardening Check ===="
 
 # Check for unnecessary packages - only if we can run apk
@@ -45,13 +49,15 @@ ALLOWED_SUID=(
 # Only check directories the user can access
 for dir in /home/ansible /usr/local/bin /bin /usr/bin; do
     if [ -d "$dir" ] && [ -r "$dir" ]; then
-        suid_files=$(find $dir -type f -perm -2000 -o -perm -4000 2>/dev/null | grep -v -E "$(
+        # Parenthesize the perm alternation so -type f binds to both branches.
+        suid_files=$(find "$dir" -type f \( -perm -2000 -o -perm -4000 \) 2>/dev/null | grep -v -E "$(
             IFS="|"
             echo "${ALLOWED_SUID[*]}"
         )" 2>/dev/null || true)
         if [ -n "$suid_files" ]; then
-            echo "WARNING: SUID/SGID binaries found in $dir (excluding allowed ones):"
+            echo "FAIL: unexpected SUID/SGID binaries found in $dir (excluding allowed ones):"
             echo "$suid_files"
+            hard_failure=1
         fi
     fi
 done
@@ -60,7 +66,8 @@ done
 echo -e "\n[+] Checking for insecure permissions..."
 for dir in /home/ansible /tmp /usr/local/bin; do
     if [ -d "$dir" ] && [ -r "$dir" ]; then
-        writable=$(find $dir -type d -perm -o+w -c 2>/dev/null)
+        # -c is a grep flag, not a find predicate: count with wc -l instead.
+        writable=$(find "$dir" -type d -perm -o+w 2>/dev/null | wc -l)
         if [ "$writable" -gt 0 ]; then
             echo "WARNING: World-writable directories found under $dir"
         fi
@@ -72,7 +79,8 @@ done
 # Check for user privileges
 echo -e "\n[+] Checking user privileges..."
 if [ "$(id -u)" = "0" ]; then
-    echo "WARNING: Container is running as root"
+    echo "FAIL: Container is running as root"
+    hard_failure=1
 else
     echo "OK: Container is running as non-root user ($(id -u))"
 fi
@@ -80,7 +88,7 @@ fi
 # Check for temporary files
 echo -e "\n[+] Checking for temporary files..."
 if [ -d "/tmp" ] && [ -r "/tmp" ]; then
-    temp_files=$(find /tmp -type f -c 2>/dev/null)
+    temp_files=$(find /tmp -type f 2>/dev/null | wc -l)
     if [ "$temp_files" -gt 0 ]; then
         echo "WARNING: Temporary files found in /tmp"
     fi
@@ -123,5 +131,9 @@ if [ -f "/etc/ssh/ssh_config" ] && [ -r "/etc/ssh/ssh_config" ]; then
 fi
 
 echo -e "\n==== Security check completed ===="
-# Always exit with success
+if [ "$hard_failure" -ne 0 ]; then
+    echo "RESULT: hard security violations found (see FAIL lines above)"
+    exit 1
+fi
+echo "RESULT: no hard security violations found"
 exit 0

--- a/tests/upgrade/test-upgrade.sh
+++ b/tests/upgrade/test-upgrade.sh
@@ -14,12 +14,24 @@ TEST_VOLUME="ansible-upgrade-test-vol"
 # Create volume if it doesn't exist
 docker volume create $TEST_VOLUME || true
 
+# A fresh named volume is owned by root:root, and Docker only adjusts that for
+# mountpoints the image already populates. The container runs as a non-root
+# user, so hand the volume over before the test writes to it.
+docker run --rm -u 0 -v "$TEST_VOLUME:/tmp/packages" "$IMAGE_NAME" \
+    chown ansible:ansible /tmp/packages
+
 # Start container with the volume mounted to /tmp/packages
 CONTAINER_ID=$(docker run -d -v "$TEST_VOLUME:/tmp/packages" "$IMAGE_NAME" tail -f /dev/null)
 
 # 2. Check if container is running
+# `docker ps` truncates IDs to 12 chars, so grepping the full 64-char ID never
+# matches; filter server-side instead.
+if [ -z "$(docker ps -q --no-trunc --filter "id=$CONTAINER_ID")" ]; then
+    echo "ERROR: container $CONTAINER_ID is not running"
+    docker logs "$CONTAINER_ID" || true
+    exit 1
+fi
 echo "Container $CONTAINER_ID is running"
-docker ps | grep "$CONTAINER_ID"
 
 # 3. Get initial version information
 echo "Collecting initial version information..."
@@ -27,12 +39,16 @@ docker exec "$CONTAINER_ID" bash -c "ansible --version | head -1 > /tmp/packages
 docker exec "$CONTAINER_ID" bash -c "cat /tmp/packages/before.txt"
 
 # 4. Install a local package that doesn't require root
+# `python` on PATH is the pipx shim, which ships no pip and rejects --user
+# installs. A venv on the mounted volume is the supported way for the non-root
+# user to install a package.
 echo "Testing local package installation..."
-docker exec "$CONTAINER_ID" bash -c "cd /tmp/packages && python -m pip install --user cowsay --no-warn-script-location"
+docker exec "$CONTAINER_ID" bash -c "python -m venv /tmp/packages/venv"
+docker exec "$CONTAINER_ID" bash -c "/tmp/packages/venv/bin/pip install cowsay --no-warn-script-location"
 
 # 5. Verify installation worked
 echo "Verifying package installation..."
-docker exec "$CONTAINER_ID" bash -c "cd /tmp/packages && python -c 'import cowsay; print(cowsay.cow(\"Upgrade test successful\"))'"
+docker exec "$CONTAINER_ID" bash -c "/tmp/packages/venv/bin/python -c 'import cowsay; print(cowsay.cow(\"Upgrade test successful\"))'"
 
 # 6. Check if container still works for Ansible operations
 echo "Testing Ansible functionality after package installation..."


### PR DESCRIPTION
## Summary

- The container hardening check ended in an unconditional `exit 0`, and both call sites wrapped it in `|| echo ...`, so a container running as root or carrying unexpected SUID binaries still reported success. The script now tracks hard violations and exits `1`; soft findings stay warnings so the full report is still printed.
- Two hardening checks were silent no-ops: `find ... -c` used a grep flag as a find predicate (leaving the variable empty and breaking the integer comparison), and the SUID search bound `-type f` to only the first branch of the perm alternation. Fixed with `wc -l` and a parenthesized alternation.
- Removed the `|| (echo ...; exit 0)` wrappers from the upgrade test and the hardening check in both the workflow and the Makefile. The security step also needs `set -o pipefail`, otherwise `tee` would keep masking the exit code.
- Removing the upgrade wrapper exposed three latent failures in that test, all fixed here: it grepped the full 64-char container ID against the 12-char `docker ps` output (never matched), the named volume stayed `root:root` and blocked writes from the non-root user, and the package install called `python -m pip --user` against a pipx shim that ships no pip. The install now uses a venv on the mounted volume.

Known remaining occurrences, left untouched as separate concerns: the Trivy scan (`Makefile:93`) suppresses its own result via `--exit-code 0`, and `tests/integration/run-integration-tests.sh:79` continues after a service-wait timeout.

## Test plan

- [x] `shellcheck` clean on the hardening and upgrade scripts, `actionlint` clean on the workflow
- [x] Hardening check inside the built image: exits `0` on the normal non-root container
- [x] Same container with `-u 0`: now exits `1` with `FAIL: Container is running as root` (previously `0`)
- [x] Replicated the exact CI step including `| tee`, confirming `pipefail` propagates the failure
- [x] Upgrade test runs green end to end against the built image (package installs, imports, Ansible still pings)
- [x] Upgrade test against a deliberately wrong image exits non-zero, confirming it can still fail
- [ ] CI green
