### PR TITLE
docs(review): correct apk pinning policy to >= lower bounds

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -25,7 +25,7 @@ Out of scope:
 - Container structure tests pass (`make structure-test`)
 - Security scans pass (gitleaks, secretlint, trivy)
 - Image runs as the non-root `ansible` user (UID/GID 1000)
-- Alpine packages use exact pins (`pkg=version-rN`) through the pkg.arillso.io proxy, never unpinned or version ranges
+- Alpine packages use `>=` lower-bound pins (`pkg>=version-rN`) through the pkg.arillso.io proxy, never unpinned, never exact `=` pins and never upper-bounded — the proxy is a pull-through cache, not an archive, so exact pins break on rebuild once Alpine rotates an old `-rN` out of dl-cdn
 - Build tools stay in the builder stage and out of the production image
 
 ## Severity levels


### PR DESCRIPTION
## Summary

- `REVIEW.md:28` required exact apk pins (`pkg=version-rN`), which contradicts the deliberate `>=` lower-bound policy documented in `Dockerfile:43-50`, `Dockerfile:93-99`, `AGENTS.md:19` and `AGENTS.md:36`
- Because `REVIEW.md` takes precedence over generic best practices in the AI review workflow, the bot flagged every correct `>=` pin in the Dockerfile as a bug on each PR
- The check now states the `>=` lower-bound rule and the reason for it: the pkg.arillso.io proxy is a pull-through cache, not an archive, so exact pins break on rebuild once Alpine rotates an old `-rN` out of dl-cdn

## Test plan

- [ ] `prettier`, `markdownlint` and `gitleaks` pass (pre-commit hooks green locally)
- [ ] CI green
- [ ] Documentation-only change — no build or runtime behavior affected