### PR TITLE
ci(merge): enable provenance, SBOM and build attestation

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,6 +22,8 @@ permissions:
     security-events: write
     actions: read
     pull-requests: write
+    id-token: write
+    attestations: write
 
 jobs:
     # Re-run the full CI and security suites as a release gate before pushing.
@@ -55,7 +57,6 @@ jobs:
         runs-on: ubuntu-latest
         needs: [ci, security]
         steps:
-
             - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               with:
@@ -313,6 +314,7 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push
+              id: build
               uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
               with:
                   context: .
@@ -326,8 +328,19 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=registry,ref=ghcr.io/arillso/ansible-cache:latest
                   cache-to: type=registry,ref=ghcr.io/arillso/ansible-cache:latest,mode=max
-                  provenance: false
-                  sbom: false
+                  provenance: true
+                  sbom: true
+
+            # Attestation covers the ghcr.io image only: the action takes a
+            # single subject-name, and push-to-registry stores the attestation
+            # next to that image. Docker Hub receives the same digest, so the
+            # ghcr attestation verifies it as well.
+            - name: Generate artifact attestation
+              uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+              with:
+                  subject-name: ghcr.io/arillso/ansible
+                  subject-digest: ${{ steps.build.outputs.digest }}
+                  push-to-registry: true
 
             - name: Create or Update Release
               uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3


### PR DESCRIPTION
## Summary

- The release build in `merge.yml` now emits provenance and an SBOM (`provenance: true`, `sbom: true`) instead of disabling both, so the published image carries verifiable supply-chain metadata.
- Added an `actions/attest-build-provenance` step that signs the build digest and pushes the attestation to the registry, following the pattern already used in `arillso/action.playbook`.
- Job permissions gained `id-token: write` and `attestations: write`, which the attestation action requires.

The test builds in `pull-request.yml` and `nightly-security.yml` keep `provenance: false` / `sbom: false` on purpose — they are not published, and disabling both keeps them fast.

Attestation covers `ghcr.io/arillso/ansible`: the action takes a single `subject-name`, and `push-to-registry` stores the attestation alongside that image. Docker Hub receives the same digest, so the ghcr attestation verifies that image as well.

## Test plan

- [ ] CI green
- [ ] After merge, the release build produces an attestation: `gh attestation verify oci://ghcr.io/arillso/ansible:latest --owner arillso`
- [ ] The published image carries an SBOM: `docker buildx imagetools inspect ghcr.io/arillso/ansible:latest`