### PR TITLE
fix(docker): run tini as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,8 @@ RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	"kustomize>=5.8.1-r2" \
 	"jq>=1.8.1-r0" \
 	"gnupg>=2.4.9-r1" \
-	"openssl>=3.5.7-r0" && \
+	"openssl>=3.5.7-r0" \
+	"tini>=0.19.0-r3" && \
 	# Reset to the public Alpine mirrors so the SHIPPED image does not depend
 	# on the private build-time proxy — downstream `apk add` uses dl-cdn.
 	printf 'https://dl-cdn.alpinelinux.org/alpine/%s/main\nhttps://dl-cdn.alpinelinux.org/alpine/%s/community\n' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,8 +179,19 @@ RUN mkdir -p /etc/ansible && \
 USER 1000:1000
 ENV ANSIBLE_FORCE_COLOR=True
 
+# tini is PID 1: it forwards signals to the actual command and reaps the
+# connection-multiplexer children Mitogen forks. Exec-form ENTRYPOINT keeps
+# CMD overridable — `docker run ... arillso/ansible bash` becomes
+# `/sbin/tini -- bash`, as documented in README.md.
+ENTRYPOINT ["/sbin/tini", "--"]
+
 # Default command
 CMD ["ansible-playbook", "--version"]
+
+# `docker stop` sends SIGTERM by default. Ansible implements a graceful
+# interrupt path for SIGINT — it finishes the running task and prints the
+# recap — but not an equivalent one for SIGTERM.
+STOPSIGNAL SIGINT
 
 # Healthcheck to verify Ansible functionality
 HEALTHCHECK --interval=30s --timeout=10s \

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,7 +192,3 @@ CMD ["ansible-playbook", "--version"]
 # interrupt path for SIGINT — it finishes the running task and prints the
 # recap — but not an equivalent one for SIGTERM.
 STOPSIGNAL SIGINT
-
-# Healthcheck to verify Ansible functionality
-HEALTHCHECK --interval=30s --timeout=10s \
-	CMD ["/bin/sh", "-c", "ansible --version || exit 1"]

--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -302,6 +302,11 @@ metadataTest:
           value: "1000"
         - key: "ANSIBLE_FORCE_COLOR"
           value: "True"
+    # tini runs as PID 1 and exec's the CMD as its own child. Exec-form
+    # ENTRYPOINT keeps the command overridable: a `docker run` argument
+    # replaces CMD only, so `docker run ... arillso/ansible bash` becomes
+    # `/sbin/tini -- bash` and still works as documented in README.md.
+    entrypoint: ["/sbin/tini", "--"]
     cmd: ["ansible-playbook", "--version"]
     workdir: "/home/ansible"
     # Numeric, matching the literal `USER 1000:1000` in the Dockerfile, which is

--- a/tests/structure/container-test.yml
+++ b/tests/structure/container-test.yml
@@ -261,6 +261,14 @@ fileExistenceTests:
       path: "/etc/alpine-release"
       shouldExist: true
 
+    # tini is the container's init (PID 1) — it forwards signals to
+    # ansible-playbook and reaps the connection-multiplexer children Mitogen
+    # forks. The ENTRYPOINT points at this exact path, so a package that
+    # installs elsewhere must fail here rather than at container start.
+    - name: "Check tini init binary exists"
+      path: "/sbin/tini"
+      shouldExist: true
+
 fileContentTests:
     - name: "Verify Alpine version"
       path: "/etc/alpine-release"


### PR DESCRIPTION
## Summary

- The container had no init process: `ansible-playbook` ran as PID 1, which under Linux ignores signals without an explicit handler, so `docker stop` fell through to `SIGKILL` and tore down a running playbook mid-task. With the Mitogen strategy, the forked connection-multiplexer children were also never reaped and accumulated as zombies.
- Installs `tini` in the production stage and sets `ENTRYPOINT ["/sbin/tini", "--"]` in exec form, which keeps the command overridable: `docker run ... arillso/ansible bash` becomes `/sbin/tini -- bash`, as documented in `README.md`. `CMD` is unchanged. `STOPSIGNAL SIGINT` maps `docker stop` onto Ansible's graceful interrupt path, which it implements for SIGINT but not equivalently for SIGTERM.
- Drops the `HEALTHCHECK`: for a task container it re-ran `ansible --version` every 30s, a result that cannot change after build, and forked a Python interpreter each time. The same command stays covered by the structure test ("Check ansible Version") and by the `test-local` target.

## Test plan

- [x] `make structure-test` — 41/41 pass, including two new anchors: `fileExistenceTests` for `/sbin/tini` and `metadataTest.entrypoint`
- [x] tini is PID 1 — `docker run --rm ansible:latest sh -c 'cat /proc/1/comm'` prints `tini`
- [x] Documented overrides still work — `ansible-playbook --version` and `bash -c 'echo override-ok'` both exit 0
- [x] Exit codes pass through (the CI gate depends on it) — `sh -c 'exit 42'` yields 42
- [x] Healthcheck gone — `docker inspect --format '{{json .Config.Healthcheck}}'` returns `null`
- [x] `make validate-docker` (hadolint) reports no findings; `make test-local` passes
- [ ] CI green