### PR TITLE
refactor(lint): align yamllint config with the org canon

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,14 +1,71 @@
 ---
 extends: default
+
 rules:
-    braces:
-        max-spaces-inside: 1
-    new-lines:
-        level: warning
-        type: unix
     line-length:
         max: 500
+        level: warning
+
     comments:
         min-spaces-from-content: 1
+
+    comments-indentation: false
+
+    indentation:
+        spaces: 4
+        indent-sequences: true
+        check-multi-line-strings: false
+
     truthy:
-        allowed-values: ["true", "false", "on"]
+        allowed-values: ["true", "false"]
+        check-keys: false
+
+    brackets:
+        min-spaces-inside: 0
+        max-spaces-inside: 0
+
+    braces:
+        min-spaces-inside: 0
+        max-spaces-inside: 1
+
+    colons:
+        max-spaces-before: 0
+        max-spaces-after: 1
+
+    commas:
+        max-spaces-before: 0
+        max-spaces-after: 1
+
+    hyphens:
+        max-spaces-after: 1
+
+    empty-lines:
+        max: 2
+        max-start: 0
+        max-end: 1
+
+    document-start:
+        present: true
+
+    document-end:
+        present: false
+
+    trailing-spaces: {}
+
+    key-duplicates: {}
+
+    new-lines:
+        type: unix
+
+    octal-values:
+        forbid-implicit-octal: true
+        forbid-explicit-octal: true
+
+ignore: |
+    .ansible/
+    .github/
+    .venv/
+    venv/
+    .tox/
+    __pycache__/
+    *.tar.gz


### PR DESCRIPTION
## Summary

- Replaces the 5-rule yamllint config with the 16-rule body shared by the Ansible collection repositories, so this repository stops being the outlier on rule coverage.
- Adds `document-start: present: true` and the standard `ignore:` block, both of which were missing here.
- Keeps the repository-specific `line-length.max: 500` and the `.yamllint.yml` filename, which already match the target convention.

### Behaviour changes carried over from the canon

- `line-length` now runs at `level: warning` instead of the default `error`, matching the collections. A line longer than 500 characters therefore warns instead of failing a non-strict run.
- The `ignore:` block excludes `.github/` from yamllint, so workflow files lose yamllint style coverage. Their semantics stay covered by `actionlint` (see `lefthook.yml`).

## Test plan

- [x] `yamllint -c .yamllint.yml .` passes locally (exit 0)
- [x] lefthook pre-commit hooks pass (yamllint, prettier, gitleaks)
- [x] CI green
