### PR TITLE
docs(license): update copyright year range to 2020-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Arillso
+Copyright (c) 2020-2026 Arillso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- The `LICENSE` copyright notice still claimed `2020` only, while the repository has active commits in 2026.
- Updated to the span `2020-2026`, matching the convention of covering project start through the current year.

## Test plan

- [ ] CI green (no code, build or config surface touched — text-only change to `LICENSE`)