### PR TITLE
ci(security): run CodeQL analysis on the Python sources

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -21,11 +21,19 @@ concurrency:
 permissions:
     contents: read
     security-events: write
+    actions: read
 
 jobs:
     codeql:
         # docker.ansible ships Python test tooling; the reusable workflow
         # defaults to Go, so the language has to be passed explicitly.
+        #
+        # security-codeql.yml uploads its SARIF unconditionally and exposes no
+        # upload toggle, so the whole job is skipped when a caller opts out —
+        # the trivy job below suppresses only its upload step for the same
+        # reason. Without this, merge.yml would still push CodeQL results on
+        # every merge to main despite passing upload-sarif: false.
+        if: ${{ !(github.event_name == 'workflow_call' && inputs.upload-sarif == false) }}
         uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
         with:
             language: python

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -23,6 +23,13 @@ permissions:
     security-events: write
 
 jobs:
+    codeql:
+        # docker.ansible ships Python test tooling; the reusable workflow
+        # defaults to Go, so the language has to be passed explicitly.
+        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
+        with:
+            language: python
+
     trivy:
         name: Trivy Scan
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- The nightly security scan built and scanned the container image and ran secret detection, but never ran static analysis, so the Python test tooling was never inspected.
- Adds a `codeql` job to `nightly-security.yml` that calls the central reusable workflow, matching how `go.ansible` and `action.playbook` wire it up.
- The reusable workflow defaults to Go, so `language: python` is passed explicitly — a bare call would analyse the wrong language here.

## Test plan

- [ ] `yamllint -c .yamllint.yml .github/workflows/nightly-security.yml` passes
- [ ] The `codeql` job appears and succeeds on the next nightly run or a manual `workflow_dispatch`
- [ ] CodeQL results show up in Code Scanning for the Python sources
- [ ] CI green