### PR TITLE
fix(scripts): keep summary generation alive when a job fails

### DIFF
--- a/.github/scripts/utils/generate-summary.sh
+++ b/.github/scripts/utils/generate-summary.sh
@@ -95,8 +95,8 @@ write_summary() {
     failed=0
     skipped=0
     for line in "${lines[@]}"; do
-        [[ "$line" == *'❌'* ]] && ((failed++))
-        [[ "$line" == *'⏭️'* ]] && ((skipped++))
+        [[ "$line" == *'❌'* ]] && ((++failed))
+        [[ "$line" == *'⏭️'* ]] && ((++skipped))
     done
     passed=$((total - failed - skipped))
 


### PR DESCRIPTION
## Summary

- `write_summary` used `((failed++))`, whose post-increment returns the pre-increment value — so the first `❌` line made the arithmetic command exit 1. As the last command carrying that status under `set -euo pipefail`, it aborted the script whenever a job was red.
- Effect: on a red job the `Generate test summary` step failed instead of writing the table, and the dependent `Comment on pull request with test results` and `Upload test results` steps were skipped. Switching to the pre-increment `((++failed))` restores the documented "always exits with 0" contract.
- Also fixes the second caller, `.github/scripts/cleanup-summary.sh`, which shares the same generator and `set -euo pipefail`.

## Test plan

- [x] Red job via `tests/scripts/container-test-summary.sh a=success b=failure`: exit 1 before, exit 0 after, title still reports `❌ FAILED`
- [x] Green, skipped-only and all-failed inputs all exit 0 with correct pass/skip/fail counts
- [x] `shellcheck tests/**/*.sh .github/scripts/**/*.sh build/*.sh` clean
- [ ] CI green