### PR TITLE
refactor(renovate): use shared alpine preset instead of local regex manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>arillso/.github:renovate-base"],
-    "customManagers": [
-        {
-            "customType": "regex",
-            "description": "Auto-detect every 'pkg>=version-rN' apk lower-bound pin in the Dockerfile and bump it via repology (Alpine alpine_3_24), including the -rN release suffix. No per-package comment markers needed — the apk add block structure is the anchor.",
-            "managerFilePatterns": ["/(^|/)Dockerfile$/"],
-            "matchStrings": [
-                "(?:apk add(?:[^\\n]*)?|\\\\)\\s+\"?(?<depName>[a-z0-9][a-z0-9._-]*)>=(?<currentValue>[a-zA-Z0-9._-]+)"
-            ],
-            "depNameTemplate": "alpine_3_24/{{{depName}}}",
-            "datasourceTemplate": "repology",
-            "versioningTemplate": "loose"
-        }
+    "extends": [
+        "github>arillso/.github:renovate-base",
+        "github>arillso/.github:renovate-alpine#2026-08-09"
     ],
     "packageRules": [
         {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ make release-check       # Pre-release validation
 
 ## Do Not
 
-- Use unpinned Alpine packages, or pin to a registry other than pkg.arillso.io (the renovate.json customManager keeps the lower bounds current)
+- Use unpinned Alpine packages, or pin to a registry other than pkg.arillso.io (the shared `renovate-alpine` preset keeps the lower bounds current)
 - Replace the `>=` lower bounds with exact `=` pins, or drop the lower bound entirely — `>=` is deliberate so Alpine's -rN rotation cannot break the build
 - Add an upper bound to the Alpine pins — the earlier upper-bound experiment (py3-pip, python3-dev) just recreated the drift pain from the other direction
 - Run as root in production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ tests/               # Unit, integration, security, performance tests
 
 ## Conventions
 
-- Alpine packages use `>=` lower-bound pins (`pkg>=version-rN`), resolved through the pkg.arillso.io caching proxy and bumped by Renovate (a customManager auto-detects every `apk add` pin via the repology datasource — no per-package markers). Lower bounds tolerate Alpine's -rN rotation: the proxy is a pull-through cache, not an archive, so exact pins break on rebuild once an old -rN drops from dl-cdn
+- Alpine packages use `>=` lower-bound pins (`pkg>=version-rN`), resolved through the pkg.arillso.io caching proxy and bumped by Renovate (the shared `renovate-alpine` preset detects every `apk add` pin via repology — no per-package markers). Lower bounds tolerate Alpine's -rN rotation: the proxy is a pull-through cache, not an archive, so exact pins break on rebuild once an old -rN drops from dl-cdn
 - Non-root user `ansible` (UID/GID 1000)
 - Mitogen enabled by default for performance
 - Multi-platform builds (amd64, arm64)

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,11 @@ COPY requirements.txt /requirements.txt
 # pull-through cache, not an archive, so once Alpine rotates an old -rN out of
 # dl-cdn an exact pin breaks on rebuild. `>=` lets apk take the current -rN and
 # tolerates that rotation, while Renovate still lifts the lower bound and the
-# text change invalidates the cache. The customManager in .github/renovate.json
-# auto-detects every pin (no per-package markers).
+# text change invalidates the cache. The shared renovate-alpine preset (see
+# .github/renovate.json) auto-detects every pin (no per-package markers). The
+# preset hardcodes the Alpine series it resolves against, so bumping the FROM
+# above to a new Alpine minor also means re-pointing that preset ref to a tag
+# whose series matches.
 RUN alpine_minor="v$(cut -d'.' -f1-2 /etc/alpine-release)" && \
 	printf 'https://pkg.arillso.io/alpine/%s/main\nhttps://pkg.arillso.io/alpine/%s/community\n' \
 		"$alpine_minor" "$alpine_minor" > /etc/apk/repositories && \


### PR DESCRIPTION
## Summary

- Drop the local `customManagers` block from `.github/renovate.json` and extend `github>arillso/.github:renovate-alpine#2026-08-09` instead, so the Alpine apk pin manager lives in one place for the whole org.
- The removed local regex used `\\` as an alternative anchor and matched any line continuation, including `ENV` blocks; that it produced no false PRs only held because every env variable is uppercase while `depName` must start with `[a-z0-9]`. The preset narrows to the `apk add` block via a two-stage `recursive` match.
- Behaviour change: the preset groups Alpine bumps into a `Alpine packages` `packageRules` group, so this repo will get fewer individual PRs than before.
- `AGENTS.md` conventions note updated to point at the shared preset rather than a local manager.

## Test plan

- [x] `renovate-config-validator .github/renovate.json` passes
- [x] Preset regex replayed against `Dockerfile`: 30 pins detected, identical dep/version pairs to the removed local regex (no detection loss, no new matches)
- [ ] CI green