### PR TITLE
fix(lint): disable MD041 for CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+
 @AGENTS.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md` is a bare `@AGENTS.md` import with no top-level heading by construction, so `MD041/first-line-heading` fired on it and the lefthook `pre-commit` markdownlint step blocked every commit that staged the file. The only workaround was `--no-verify`, which also disables gitleaks, yamllint, hadolint and actionlint.
- Adds `<!-- markdownlint-disable-file MD041 -->` as the first line, matching the pattern already used in `arillso/ansible.agent`. `.markdownlint.json` is left untouched so the org-wide rule set stays as is.
- Completes the MD041 fix that #558 deliberately left open for this repo.

## Test plan

- [x] `markdownlint-cli2 CLAUDE.md` — fails with `MD041` before, 0 issues after
- [x] `markdownlint-cli2 '**/*.md'` — all 5 markdown files clean, no other MD041 offenders in the repo
- [x] `prettier --check CLAUDE.md` — passes
- [x] Full lefthook `pre-commit` run on the staged file — gitleaks, prettier and markdownlint all pass
- [ ] CI green